### PR TITLE
Remove smart-auto-base-path logic, it breaks razor. Use absolute paths.

### DIFF
--- a/FileSystem.sln
+++ b/FileSystem.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.21916.0
+VisualStudioVersion = 14.0.22013.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A1477614-E825-4204-A684-385004B63AEB}"
 EndProject
@@ -10,6 +10,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{E399495E-82B8-4C06-8779-C1D02BEF4495}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.FileSystems.Tests", "test\Microsoft.AspNet.FileSystems.Tests\Microsoft.AspNet.FileSystems.Tests.kproj", "{66FE5FDF-BBF9-4573-A7B7-53551731C0F9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1A060559-74DD-4B5A-BBA1-E8A441E729C1}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Microsoft.AspNet.FileSystems/PhysicalFileSystem.cs
+++ b/src/Microsoft.AspNet.FileSystems/PhysicalFileSystem.cs
@@ -50,7 +50,13 @@ namespace Microsoft.AspNet.FileSystems
         /// <param name="root">The root directory. This should be an absolute path.</param>
         public PhysicalFileSystem(string root)
         {
-            Root = GetFullRoot(root);
+            if (!Path.IsPathRooted(root))
+            {
+                throw new ArgumentException("The path must be absolute.", "root");
+            }
+            var fullRoot = Path.GetFullPath(root);
+            // When we do matches in GetFullPath, we want to only match full directory names.
+            Root = EnsureTrailingSlash(fullRoot);
             if (!Directory.Exists(Root))
             {
                 throw new DirectoryNotFoundException(Root);
@@ -61,14 +67,6 @@ namespace Microsoft.AspNet.FileSystems
         /// The root directory for this instance.
         /// </summary>
         public string Root { get; private set; }
-
-        private static string GetFullRoot(string root)
-        {
-            var fullRoot = Path.GetFullPath(root);
-            // When we do matches in GetFullPath, we want to only match full directory names.
-            fullRoot = EnsureTrailingSlash(fullRoot);
-            return fullRoot;
-        }
 
         private string GetFullPath(string path)
         {

--- a/test/Microsoft.AspNet.FileSystems.Tests/PhysicalFileSystemTests.cs
+++ b/test/Microsoft.AspNet.FileSystems.Tests/PhysicalFileSystemTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.FileSystems
         [Fact]
         public void ExistingFilesReturnTrue()
         {
-            var provider = new PhysicalFileSystem(".");
+            var provider = new PhysicalFileSystem(Environment.CurrentDirectory);
             IFileInfo info;
             provider.TryGetFileInfo("File.txt", out info).ShouldBe(true);
             info.ShouldNotBe(null);
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.FileSystems
         [Fact]
         public void MissingFilesReturnFalse()
         {
-            var provider = new PhysicalFileSystem(".");
+            var provider = new PhysicalFileSystem(Environment.CurrentDirectory);
             IFileInfo info;
             provider.TryGetFileInfo("File5.txt", out info).ShouldBe(false);
             info.ShouldBe(null);
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.FileSystems
         [Fact]
         public void SubPathActsAsRoot()
         {
-            var provider = new PhysicalFileSystem("sub");
+            var provider = new PhysicalFileSystem(Path.Combine(Environment.CurrentDirectory, "sub"));
             IFileInfo info;
             provider.TryGetFileInfo("File2.txt", out info).ShouldBe(true);
             info.ShouldNotBe(null);
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.FileSystems
             var serviceProvider = CallContextServiceLocator.Locator.ServiceProvider;
             var appEnvironment = (IApplicationEnvironment)serviceProvider.GetService(typeof(IApplicationEnvironment));
 
-            var provider = new PhysicalFileSystem("sub");
+            var provider = new PhysicalFileSystem(Path.Combine(Environment.CurrentDirectory, "sub"));
             IFileInfo info;
 
             provider.TryGetFileInfo("..\\File.txt", out info).ShouldBe(false);
@@ -77,7 +77,7 @@ namespace Microsoft.AspNet.FileSystems
         public void TryGetParentPath_ReturnsFalseIfPathIsNullOrEmpty(string subpath)
         {
             // Arrange
-            var provider = new PhysicalFileSystem("sub");
+            var provider = new PhysicalFileSystem(Path.Combine(Environment.CurrentDirectory, "sub"));
 
             // Act and Assert
             provider.TryGetParentPath(subpath, out var parentPath).ShouldBe(false);
@@ -98,7 +98,7 @@ namespace Microsoft.AspNet.FileSystems
         public void TryGetParentPath_ReturnsFalseIfPathIsNotSubDirectoryOfRoot(string subpath)
         {
             // Arrange
-            var provider = new PhysicalFileSystem("sub");
+            var provider = new PhysicalFileSystem(Path.Combine(Environment.CurrentDirectory, "sub"));
 
             // Act and Assert
             provider.TryGetParentPath(subpath, out var parentPath).ShouldBe(false);
@@ -113,7 +113,7 @@ namespace Microsoft.AspNet.FileSystems
         public void TryGetParentPath_ReturnsParentPath(string root, string subpath, string expected)
         {
             // Arrange
-            var provider = new PhysicalFileSystem(root);
+            var provider = new PhysicalFileSystem(Path.Combine(Environment.CurrentDirectory, root));
 
             // Act and Assert
             provider.TryGetParentPath(subpath, out var parentPath).ShouldBe(true);
@@ -128,7 +128,7 @@ namespace Microsoft.AspNet.FileSystems
         public void TryGetParentPath_AllowsTraversingToTheRoot(string input)
         {
             // Arrange
-            var provider = new PhysicalFileSystem("");
+            var provider = new PhysicalFileSystem(Environment.CurrentDirectory);
 
             // Act and Assert - 1
             provider.TryGetParentPath(input, out var path1).ShouldBe(true);

--- a/test/Microsoft.AspNet.FileSystems.Tests/project.json
+++ b/test/Microsoft.AspNet.FileSystems.Tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.AspNet.FileSystems": "",
+    "Microsoft.AspNet.FileSystems": "1.0.0-*",
     "Shouldly": "1.1.1.1",
     "Xunit.KRunner": "1.0.0-*"
   },


### PR DESCRIPTION
#17

The caller is responsible for any fancy base path determinations. See https://github.com/aspnet/StaticFiles/pull/9
