### PR TITLE
Fixing build break on CoreCLR - adding System.Threading to coreclr depen...

### DIFF
--- a/src/Microsoft.AspNet.FileSystems/project.json
+++ b/src/Microsoft.AspNet.FileSystems/project.json
@@ -13,7 +13,8 @@
                 "System.IO.FileSystem.Watcher": "4.0.0-beta-*",
                 "System.IO.FileSystem": "4.0.0-beta-*",
                 "System.Linq": "4.0.0-beta-*",
-                "System.Text.RegularExpressions": "4.0.10-beta-*"
+                "System.Text.RegularExpressions": "4.0.10-beta-*",
+                "System.Threading": "4.0.0-beta-*"
             }
         }
     }


### PR DESCRIPTION
...dencies.

VS seems to build the project fine. Looks like on CoreCLR this missing package is causing the build break.
