### PR TITLE
Handling the directory rename case for file system watcher

### DIFF
--- a/test/Microsoft.AspNet.FileSystems.Tests/PhysicalFileSystemTests.cs
+++ b/test/Microsoft.AspNet.FileSystems.Tests/PhysicalFileSystemTests.cs
@@ -491,7 +491,7 @@ namespace Microsoft.AspNet.FileSystems
         public async Task Triggers_With_Regular_Expressions()
         {
             var pattern1 = "**/*";
-            var pattern2 = "*";
+            var pattern2 = "*.cshtml";
             var root = Path.GetTempPath();
             var fileName = Guid.NewGuid().ToString();
             var subFolder = Path.Combine(root, Guid.NewGuid().ToString());


### PR DESCRIPTION
Today when a trigger is registered for items under a directory and when the directory is renamed FSW only fires an event for the directory change, but not for the files/sub-directories under it. So if there are triggeres setup for sub-items, they they trigger on folder rename. This fix addresses the issue, by handling a directory change event and raising the trigger for the file system entries under the renamed directory.

@davidfowl @pranavkm 