### PR TITLE
Modify FileChangeTrigger to additionally check for files on disk

### DIFF
--- a/src/Microsoft.AspNet.FileSystems/AssemblyInfo.cs
+++ b/src/Microsoft.AspNet.FileSystems/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.AspNet.FileSystems.Tests")]

--- a/src/Microsoft.AspNet.FileSystems/Implementation/FileExpirationTriggerBase.cs
+++ b/src/Microsoft.AspNet.FileSystems/Implementation/FileExpirationTriggerBase.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Framework.Expiration.Interfaces;
+
+namespace Microsoft.AspNet.FileSystems
+{
+    public abstract class FileExpirationTriggerBase : IExpirationTrigger
+    {
+        public bool ActiveExpirationCallbacks
+        {
+            get { return true; }
+        }
+
+        protected CancellationTokenSource TokenSource { get; } = new CancellationTokenSource();
+
+        public virtual bool IsExpired
+        {
+            get { return TokenSource.Token.IsCancellationRequested; }
+        }
+
+        public IDisposable RegisterExpirationCallback(Action<object> callback, object state)
+        {
+            return TokenSource.Token.Register(callback, state);
+        }
+
+        /// <remarks>
+        /// The <see cref="Task"/> returned by this method is not waited on by the calling code. It's only purpose
+        /// is to guarantee the correct sequence of events for unit tests.
+        /// </remarks>
+        public Task Changed()
+        {
+            return Task.Run(() =>
+            {
+                try
+                {
+                    TokenSource.Cancel();
+                }
+                catch
+                {
+                }
+            });
+        }
+    }
+}

--- a/src/Microsoft.AspNet.FileSystems/Implementation/WildcardFileChangeTrigger.cs
+++ b/src/Microsoft.AspNet.FileSystems/Implementation/WildcardFileChangeTrigger.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.AspNet.FileSystems
+{
+    internal class WildcardFileChangeTrigger : FileExpirationTriggerBase
+    {
+        private Regex _searchRegex;
+
+        public WildcardFileChangeTrigger(string pattern)
+        {
+            Pattern = pattern;
+        }
+
+        public string Pattern { get; }
+
+        private Regex SearchRegex
+        {
+            get
+            {
+                if (_searchRegex == null)
+                {
+                    // Perf: Compile this as this may be used multiple times.
+                    _searchRegex = new Regex('^' + Pattern + '$', RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
+                }
+
+                return _searchRegex;
+            }
+        }
+
+        public bool IsMatch(string relativePath)
+        {
+            return SearchRegex.IsMatch(relativePath);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.FileSystems/PhysicalFileSystem.cs
+++ b/src/Microsoft.AspNet.FileSystems/PhysicalFileSystem.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNet.FileSystems
             }
 
             // Monitor only the application's root folder.
-            _physicalFileSystemWatcher = new PhysicalFileSystemWatcher(Root);
+            _physicalFileSystemWatcher = new PhysicalFileSystemWatcher(this);
         }
 
         /// <summary>

--- a/test/Microsoft.AspNet.FileSystems.Tests/FileChangeTriggerTests.cs
+++ b/test/Microsoft.AspNet.FileSystems.Tests/FileChangeTriggerTests.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.FileSystems
+{
+    public class FileChangeTriggerTests
+    {
+        [Fact]
+        public void IsExpired_ReturnsFalse_IfCancellationTokenSourceIsNotExpired_AndFileIsUnchanged()
+        {
+            // Arrange
+            var path = "my/path/tofile.txt";
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem.Setup(f => f.GetFileInfo(path))
+                      .Returns(new NotFoundFileInfo(path))
+                      .Verifiable();
+            var trigger = new TestFileChangeTrigger(fileSystem.Object, path);
+
+            // Act - 1
+            trigger.AddTime(TimeSpan.FromSeconds(1));
+            var result = trigger.IsExpired;
+
+            // Assert - 1
+            Assert.False(result);
+            fileSystem.Verify(f => f.GetFileInfo(path), Times.Once());
+
+            // Act - 2
+            trigger.AddTime(TimeSpan.FromSeconds(5));
+            result = trigger.IsExpired;
+
+            // Assert - 1
+            Assert.False(result);
+            fileSystem.Verify(f => f.GetFileInfo(path), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task IsExpired_ReturnsTrue_IfCancellationTokenSourceIsExpired()
+        {
+            // Arrange
+            var path = "my/path/tofile.txt";
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem.Setup(f => f.GetFileInfo(path))
+                      .Returns(new NotFoundFileInfo(path))
+                      .Verifiable();
+            var trigger = new TestFileChangeTrigger(fileSystem.Object, path);
+            await trigger.Changed();
+
+            // Act
+            var result = trigger.IsExpired;
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsExpired_ReturnsTrue_IfFileHasChangedButCancellationTokenHasNotFired()
+        {
+            // Arrange
+            var path = "my/path/tofile.txt";
+            var newFile = new Mock<IFileInfo>();
+            newFile.SetupGet(f => f.LastModified)
+                   .Returns(DateTimeOffset.UtcNow.AddSeconds(10));
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem.Setup(f => f.GetFileInfo(path))
+                      .Returns(new NotFoundFileInfo(path))
+                      .Verifiable();
+            var trigger = new TestFileChangeTrigger(fileSystem.Object, path);
+
+            // Act - 1
+            var result = trigger.IsExpired;
+
+            // Assert - 1
+            Assert.False(result);
+
+            // Act - 2
+            fileSystem.Setup(f => f.GetFileInfo(path))
+                      .Returns(newFile.Object)
+                      .Verifiable();
+            trigger.AddTime(TimeSpan.FromSeconds(4));
+            result = trigger.IsExpired;
+
+            // Assert - 2
+            Assert.True(result);
+        }
+
+        private class TestFileChangeTrigger : FileChangeTrigger
+        {
+            private DateTime _utcNow = DateTime.UtcNow;
+
+            public TestFileChangeTrigger(IFileSystem fileSystem, string path) 
+                : base(fileSystem, path)
+            {
+            }
+
+            protected override DateTime UtcNow
+            {
+                get { return _utcNow; }
+            }
+
+            public void AddTime(TimeSpan timeSpan)
+            {
+                _utcNow = _utcNow.Add(timeSpan);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.FileSystems.Tests/project.json
+++ b/test/Microsoft.AspNet.FileSystems.Tests/project.json
@@ -1,6 +1,7 @@
 {
     "dependencies": {
         "Microsoft.AspNet.FileSystems": "1.0.0-*",
+        "Moq": "4.2.1312.1622",
         "Shouldly": "1.1.1.1",
         "xunit.runner.kre": "1.0.0-*"
     },


### PR DESCRIPTION
In the event the FileSystemWatcher fails to fire file system notifications
events.