### PR TITLE
Fixing a test failure on Win7

### DIFF
--- a/test/Microsoft.AspNet.FileSystems.Tests/PhysicalFileSystemTests.cs
+++ b/test/Microsoft.AspNet.FileSystems.Tests/PhysicalFileSystemTests.cs
@@ -489,7 +489,7 @@ namespace Microsoft.AspNet.FileSystems
         public async Task Triggers_With_Regular_Expressions()
         {
             var pattern1 = "**/*";
-            var pattern2 = "*";
+            var pattern2 = "*.cshtml";
             var root = Path.GetTempPath();
             var fileName = Guid.NewGuid().ToString();
             var subFolder = Path.Combine(root, Guid.NewGuid().ToString());


### PR DESCRIPTION
This test specifically tests triggers with regular expressions where it looks for changes in root directrory in one trigger and another trigger monitoring any change in any sub-directory (recursive).

On Win7 when a file is modified we see a directory changed event is triggered on the parent directory automatically. This results in a flaky run on Win7. So making the test bit more restrictive to fix flakiness on Win7.