### PR TITLE
Fix the incorrect matched parent path segment

### DIFF
--- a/src/Microsoft.Framework.FileSystemGlobbing/Abstractions/DirectoryInfoWrapper.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Abstractions/DirectoryInfoWrapper.cs
@@ -14,7 +14,13 @@ namespace Microsoft.Framework.FileSystemGlobbing.Abstractions
 
         public DirectoryInfoWrapper(DirectoryInfo directoryInfo, bool isParentPath = false)
         {
-            _directoryInfo = directoryInfo;
+            // Work around for https://github.com/dotnet/corefx/issues/616: DirectoryInfo.Exists returns 
+            // incorrect results when it is cast from FileSystemInfo.
+            //
+            // Once it is fixed us following line to replace the assignment to _directoryInfo
+            // _directoryInfo = directoryInfo.FullName;
+            _directoryInfo = new DirectoryInfo(directoryInfo.FullName);
+
             _isParentPath = isParentPath;
         }
 

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/MatcherContext.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/MatcherContext.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal
             {
                 entities = _declaredLiteralFolderSegments.Select(literal => directory.GetDirectory(literal.Value));
             }
+
             if (_declaredParentPathSegment)
             {
                 entities = entities.Concat(new[] { directory.GetDirectory("..") });

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextRagged.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextRagged.cs
@@ -42,6 +42,11 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
                     frame.SegmentIndex += 1;
                 }
             }
+            else if (!IsStartingGroup() && directory.Name == "..")
+            {
+                // any parent path segment is not applicable in **
+                frame.IsNotApplicable = true;
+            }
             else if (!IsStartingGroup() && !IsEndingGroup() && TestMatchingGroup(directory))
             {
                 frame.SegmentIndex = Frame.SegmentGroup.Count;

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/FileAbstractionsTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/FileAbstractionsTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNet.Testing.xunit;
@@ -20,8 +19,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests
             {
                 var contents = scenario.DirectoryInfo.EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly);
 
-                Assert.Equal(Path.GetFileName(scenario.TempFolder), scenario.DirectoryInfo.Name);
-                Assert.Equal(scenario.TempFolder, scenario.DirectoryInfo.FullName);
+                Assert.Equal(Path.GetFileName(scenario.RootPath), scenario.DirectoryInfo.Name);
+                Assert.Equal(scenario.RootPath, scenario.DirectoryInfo.FullName);
                 Assert.Equal(0, contents.Count());
             }
         }
@@ -96,38 +95,6 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests
                 Assert.Equal("beta", beta.Name);
                 Assert.Equal(1, contents2.Count());
                 Assert.Equal("alpha.txt", alphaTxt.Name);
-            }
-        }
-
-        private class DisposableFileSystem : IDisposable
-        {
-            public DisposableFileSystem()
-            {
-                TempFolder = Path.GetTempFileName();
-                File.Delete(TempFolder);
-                Directory.CreateDirectory(TempFolder);
-                DirectoryInfo = new DirectoryInfoWrapper(new DirectoryInfo(TempFolder));
-            }
-
-            public string TempFolder { get; }
-
-            public DirectoryInfoBase DirectoryInfo { get; }
-
-            public DisposableFileSystem CreateFolder(string path)
-            {
-                Directory.CreateDirectory(Path.Combine(TempFolder, path));
-                return this;
-            }
-
-            public DisposableFileSystem CreateFile(string path)
-            {
-                File.WriteAllText(Path.Combine(TempFolder, path), "temp");
-                return this;
-            }
-
-            public void Dispose()
-            {
-                Directory.Delete(TempFolder, true);
             }
         }
     }

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/FileAbstractionsTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/FileAbstractionsTests.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Linq;
-using Microsoft.AspNet.Testing.xunit;
 using Microsoft.Framework.FileSystemGlobbing.Abstractions;
 using Microsoft.Framework.FileSystemGlobbing.Tests.TestUtility;
 using Xunit;
@@ -55,8 +54,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests
             }
         }
 
-        [ConditionalFact]
-        [RunWhenWhenDirectoryInfoWorks]
+        [Fact]
         public void SubFoldersAreEnumerated()
         {
             using (var scenario = new DisposableFileSystem()

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/FunctionalTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/FunctionalTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using Microsoft.AspNet.Testing.xunit;
 using Microsoft.Framework.FileSystemGlobbing.Abstractions;
 using Microsoft.Framework.FileSystemGlobbing.Tests.TestUtility;
 using Xunit;
@@ -131,6 +132,15 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests
                 "src/project2/compiler/shared/sub/sub/sharedsub.cs");
         }
 
+#if ASPNETCORE50
+        [ConditionalFact]
+        [RunWhenWhenDirectoryInfoWorks]
+        public void WarningTest()
+        {
+
+        }
+#endif
+
         private DisposableFileSystem CreateContext()
         {
             var context = new DisposableFileSystem();
@@ -197,7 +207,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests
             var actual = results.Files.Select(relativePath => Path.GetFullPath(Path.Combine(_context.RootPath, directoryPath, relativePath)));
             var expect = expectFiles.Select(relativePath => Path.GetFullPath(Path.Combine(_context.RootPath, relativePath)));
 
-            AssertHelpers.SortAndEqual(expect, actual, StringComparer.InvariantCultureIgnoreCase);
+            AssertHelpers.SortAndEqual(expect, actual, StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/FunctionalTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/FunctionalTests.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Framework.FileSystemGlobbing.Abstractions;
+using Microsoft.Framework.FileSystemGlobbing.Tests.TestUtility;
+using Xunit;
+
+namespace Microsoft.Framework.FileSystemGlobbing.Tests
+{
+    public class FunctionalTests : IDisposable
+    {
+        private DisposableFileSystem _context;
+
+        public FunctionalTests()
+        {
+            _context = CreateContext();
+        }
+
+        public void Dispose()
+        {
+            if (_context != null)
+            {
+                _context.Dispose();
+            }
+        }
+
+        [Fact]
+        public void RecursiveAndDoubleParentsWithRecursiveSearch()
+        {
+            var matcher = new Matcher();
+            matcher.AddInclude("**/*.cs")
+                   .AddInclude(@"../../lib/**/*.cs");
+
+            ExecuteAndVerify(matcher, @"src/project",
+                "src/project/source1.cs",
+                "src/project/sub/source2.cs",
+                "src/project/sub/source3.cs",
+                "src/project/sub2/source4.cs",
+                "src/project/sub2/source5.cs",
+                "src/project/compiler/preprocess/preprocess-source1.cs",
+                "src/project/compiler/preprocess/sub/preprocess-source2.cs",
+                "src/project/compiler/preprocess/sub/sub/preprocess-source3.cs",
+                "src/project/compiler/shared/shared1.cs",
+                "src/project/compiler/shared/sub/shared2.cs",
+                "src/project/compiler/shared/sub/sub/sharedsub.cs",
+                "lib/source6.cs",
+                "lib/sub3/source7.cs",
+                "lib/sub4/source8.cs");
+        }
+
+        [Fact]
+        public void RecursiveAndDoubleParentsSearch()
+        {
+            var matcher = new Matcher();
+            matcher.AddInclude("**/*.cs")
+                   .AddInclude(@"../../lib/*.cs");
+
+            ExecuteAndVerify(matcher, @"src/project",
+                "src/project/source1.cs",
+                "src/project/sub/source2.cs",
+                "src/project/sub/source3.cs",
+                "src/project/sub2/source4.cs",
+                "src/project/sub2/source5.cs",
+                "src/project/compiler/preprocess/preprocess-source1.cs",
+                "src/project/compiler/preprocess/sub/preprocess-source2.cs",
+                "src/project/compiler/preprocess/sub/sub/preprocess-source3.cs",
+                "src/project/compiler/shared/shared1.cs",
+                "src/project/compiler/shared/sub/shared2.cs",
+                "src/project/compiler/shared/sub/sub/sharedsub.cs",
+                "lib/source6.cs");
+        }
+
+        [Fact]
+        public void WildcardAndDoubleParentWithRecursiveSearch()
+        {
+            var matcher = new Matcher();
+            matcher.AddInclude(@"..\..\lib\**\*.cs");
+            matcher.AddInclude(@"*.cs");
+
+            ExecuteAndVerify(matcher, @"src/project",
+                "src/project/source1.cs",
+                "lib/source6.cs",
+                "lib/sub3/source7.cs",
+                "lib/sub4/source8.cs");
+        }
+
+        [Fact]
+        public void WildcardAndDoubleParentsSearch()
+        {
+            var matcher = new Matcher();
+            matcher.AddInclude(@"..\..\lib\*.cs");
+            matcher.AddInclude(@"*.cs");
+
+            ExecuteAndVerify(matcher, @"src/project",
+                "src/project/source1.cs",
+                "lib/source6.cs");
+        }
+
+        [Fact]
+        public void DoubleParentsWithRecursiveSearch()
+        {
+            var matcher = new Matcher();
+            matcher.AddInclude(@"..\..\lib\**\*.cs");
+
+            ExecuteAndVerify(matcher, @"src/project",
+                "lib/source6.cs",
+                "lib/sub3/source7.cs",
+                "lib/sub4/source8.cs");
+        }
+
+        [Fact]
+        public void OneLevelParentAndRecursiveSearch()
+        {
+            var matcher = new Matcher();
+            matcher.AddInclude(@"../project2/**/*.cs");
+
+            ExecuteAndVerify(matcher, @"src/project",
+                "src/project2/source1.cs",
+                "src/project2/sub/source2.cs",
+                "src/project2/sub/source3.cs",
+                "src/project2/sub2/source4.cs",
+                "src/project2/sub2/source5.cs",
+                "src/project2/compiler/preprocess/preprocess-source1.cs",
+                "src/project2/compiler/preprocess/sub/preprocess-source2.cs",
+                "src/project2/compiler/preprocess/sub/sub/preprocess-source3.cs",
+                "src/project2/compiler/shared/shared1.cs",
+                "src/project2/compiler/shared/sub/shared2.cs",
+                "src/project2/compiler/shared/sub/sub/sharedsub.cs");
+        }
+
+        private DisposableFileSystem CreateContext()
+        {
+            var context = new DisposableFileSystem();
+            context.CreateFiles(
+                "src/project/source1.cs",
+                "src/project/sub/source2.cs",
+                "src/project/sub/source3.cs",
+                "src/project/sub2/source4.cs",
+                "src/project/sub2/source5.cs",
+                "src/project/compiler/preprocess/preprocess-source1.cs",
+                "src/project/compiler/preprocess/sub/preprocess-source2.cs",
+                "src/project/compiler/preprocess/sub/sub/preprocess-source3.cs",
+                "src/project/compiler/preprocess/sub/sub/preprocess-source3.txt",
+                "src/project/compiler/shared/shared1.cs",
+                "src/project/compiler/shared/shared1.txt",
+                "src/project/compiler/shared/sub/shared2.cs",
+                "src/project/compiler/shared/sub/shared2.txt",
+                "src/project/compiler/shared/sub/sub/sharedsub.cs",
+                "src/project/compiler/resources/resource.res",
+                "src/project/compiler/resources/sub/resource2.res",
+                "src/project/compiler/resources/sub/sub/resource3.res",
+                "src/project/content1.txt",
+                "src/project/obj/object.o",
+                "src/project/bin/object",
+                "src/project/.hidden/file1.hid",
+                "src/project/.hidden/sub/file2.hid",
+                "src/project2/source1.cs",
+                "src/project2/sub/source2.cs",
+                "src/project2/sub/source3.cs",
+                "src/project2/sub2/source4.cs",
+                "src/project2/sub2/source5.cs",
+                "src/project2/compiler/preprocess/preprocess-source1.cs",
+                "src/project2/compiler/preprocess/sub/preprocess-source2.cs",
+                "src/project2/compiler/preprocess/sub/sub/preprocess-source3.cs",
+                "src/project2/compiler/preprocess/sub/sub/preprocess-source3.txt",
+                "src/project2/compiler/shared/shared1.cs",
+                "src/project2/compiler/shared/shared1.txt",
+                "src/project2/compiler/shared/sub/shared2.cs",
+                "src/project2/compiler/shared/sub/shared2.txt",
+                "src/project2/compiler/shared/sub/sub/sharedsub.cs",
+                "src/project2/compiler/resources/resource.res",
+                "src/project2/compiler/resources/sub/resource2.res",
+                "src/project2/compiler/resources/sub/sub/resource3.res",
+                "src/project2/content1.txt",
+                "src/project2/obj/object.o",
+                "src/project2/bin/object",
+                "lib/source6.cs",
+                "lib/sub3/source7.cs",
+                "lib/sub4/source8.cs",
+                "res/resource1.text",
+                "res/resource2.text",
+                "res/resource3.text",
+                ".hidden/file1.hid",
+                ".hidden/sub/file2.hid");
+
+            return context;
+        }
+
+        private void ExecuteAndVerify(Matcher matcher, string directoryPath, params string[] expectFiles)
+        {
+            directoryPath = Path.Combine(_context.RootPath, directoryPath);
+            var results = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(directoryPath)));
+
+            var actual = results.Files.Select(relativePath => Path.GetFullPath(Path.Combine(_context.RootPath, directoryPath, relativePath)));
+            var expect = expectFiles.Select(relativePath => Path.GetFullPath(Path.Combine(_context.RootPath, relativePath)));
+
+            AssertHelpers.SortAndEqual(expect, actual, StringComparer.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternMatchingTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternMatchingTests.cs
@@ -336,7 +336,6 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests
             scenario.AssertExact("1.txt", "2.txt", "../sibling/1.txt", "../sibling/inc/1.txt");
         }
 
-
         [Fact]
         public void ExcludeFolderByName()
         {

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/Patterns/PatternTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/Patterns/PatternTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Framework.FileSystemGlobbing.Internal;
 using Microsoft.Framework.FileSystemGlobbing.Internal.Patterns;
 using Xunit;
@@ -21,6 +22,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
         [InlineData("abc/efg/h*j/*.*/", 4)]
         [InlineData("abc/efg/hij", 3)]
         [InlineData("abc/efg/hij/klm", 4)]
+        [InlineData("../abc/efg/hij/klm", 5)]
+        [InlineData("../../abc/efg/hij/klm", 6)]
         public void BuildLinearPattern(string sample, int segmentCount)
         {
             var pattern = PatternBuilder.Build(sample);
@@ -99,6 +102,31 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
             var pattern = PatternBuilder.Build(sample) as IRaggedPattern;
 
             Assert.Null(pattern);
+        }
+
+        [Theory]
+        [InlineData("a/../")]
+        [InlineData("a/..")]
+        [InlineData("/a/../")]
+        [InlineData("./a/../")]
+        [InlineData("**/../")]
+        [InlineData("*.cs/../")]
+        public void ThrowExceptionForInvalidParentsPath(string sample)
+        {
+            // parent segment is only allowed at the beginning of the pattern
+            Assert.Throws<ArgumentException>(() => {
+                var pattern = PatternBuilder.Build(sample);
+
+                Assert.Null(pattern);
+            });
+        }
+
+        [Fact]
+        public void ThrowExceptionForNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => {
+                PatternBuilder.Build(null);
+            });
         }
     }
 }

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/AssertHelpers.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/AssertHelpers.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Framework.FileSystemGlobbing.Tests.TestUtility
+{
+    public static class AssertHelpers
+    {
+        public static void SortAndEqual<T>(IEnumerable<T> expect, IEnumerable<T> actual, IEqualityComparer<T> comparer)
+        {
+            var missing = expect.Except(actual, comparer);
+            var extra = actual.Except(expect, comparer);
+            var errorMessage = new StringBuilder("Two collections are not equal");
+
+            if (missing.Any())
+            {
+                errorMessage.Append("\nMissing:\n");
+                foreach (var missedElement in missing)
+                {
+                    errorMessage.AppendFormat("\t{0}\n", missedElement.ToString());
+                }
+            }
+
+            if (extra.Any())
+            {
+                errorMessage.Append("\nExtra:\n");
+                foreach (var extraElement in extra)
+                {
+                    errorMessage.AppendFormat("\t{0}\n", extraElement.ToString());
+                }
+            }
+
+            Assert.True(!missing.Any() && !extra.Any(), errorMessage.ToString());
+        }
+    }
+}

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/DisposableFileSystem.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/DisposableFileSystem.cs
@@ -44,9 +44,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.TestUtility
 
                 File.WriteAllText(
                     fullPath,
-                    string.Format("Automatically generated for testing on {0} {1}",
-                        DateTime.Now.ToLongDateString(),
-                        DateTime.Now.ToLongTimeString()));
+                    string.Format("Automatically generated for testing on {0:yyyy}/{0:MM}/{0:dd} {0:hh}:{0:mm}:{0:ss}", DateTime.Now));
             }
 
             return this;

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/DisposableFileSystem.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/DisposableFileSystem.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Framework.FileSystemGlobbing.Abstractions;
+
+namespace Microsoft.Framework.FileSystemGlobbing.Tests.TestUtility
+{
+    public class DisposableFileSystem : IDisposable
+    {
+        private readonly bool _automaticCleanup;
+
+        public DisposableFileSystem(bool automaticCleanup = true)
+        {
+            RootPath = Path.GetTempFileName();
+            File.Delete(RootPath);
+            Directory.CreateDirectory(RootPath);
+            DirectoryInfo = new DirectoryInfoWrapper(new DirectoryInfo(RootPath));
+        }
+
+        public string RootPath { get; }
+
+        public DirectoryInfoBase DirectoryInfo { get; }
+
+        public DisposableFileSystem CreateFolder(string path)
+        {
+            Directory.CreateDirectory(Path.Combine(RootPath, path));
+            return this;
+        }
+
+        public DisposableFileSystem CreateFile(string path)
+        {
+            File.WriteAllText(Path.Combine(RootPath, path), "temp");
+            return this;
+        }
+
+        public DisposableFileSystem CreateFiles(params string[] fileRelativePaths)
+        {
+            foreach (var path in fileRelativePaths)
+            {
+                var fullPath = Path.Combine(RootPath, path);
+                Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
+
+                File.WriteAllText(
+                    fullPath,
+                    string.Format("Automatically generated for testing on {0} {1}",
+                        DateTime.Now.ToLongDateString(),
+                        DateTime.Now.ToLongTimeString()));
+            }
+
+            return this;
+        }
+
+        public void Dispose()
+        {
+            if (_automaticCleanup)
+            {
+                Directory.Delete(RootPath, true);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/RunWhenWhenDirectoryInfoWorksAttribute.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/RunWhenWhenDirectoryInfoWorksAttribute.cs
@@ -7,7 +7,8 @@ using System.Linq;
 
 namespace Microsoft.Framework.FileSystemGlobbing.Tests.TestUtility
 {
-    public class RunWhenWhenDirectoryInfoWorksAttribute : Attribute, Microsoft.AspNet.Testing.xunit.ITestCondition
+    public class RunWhenWhenDirectoryInfoWorksAttribute :
+        Attribute, Microsoft.AspNet.Testing.xunit.ITestCondition
     {
         public bool IsMet
         {
@@ -21,7 +22,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.TestUtility
         {
             get
             {
-                return "CoreCLR DirectoryInfo incorrectly text directory existence.";
+                return "Issue: \"DirectoryInfo.Exists returns incorrect results when it is cast from FileSystemInfo.\" is fixed. Please remove the workaround in the produce code and this test case.";
             }
         }
 
@@ -40,7 +41,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.TestUtility
                 Directory.CreateDirectory(betaDir);
 
                 var beta = testDir.EnumerateFileSystemInfos("beta", SearchOption.TopDirectoryOnly).First() as DirectoryInfo;
-                return beta.Exists;
+                return !beta.Exists;
             }
             finally
             {

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/project.json
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/project.json
@@ -8,7 +8,11 @@
 
     "frameworks": {
         "aspnet50": { },
-        "aspnetcore50": { }
+        "aspnetcore50": {
+            "dependencies": {
+                "System.Runtime": "4.0.20-*"
+            }
+        }
     },
     "commands": {
         "test": "xunit.runner.kre"


### PR DESCRIPTION
## Fixing following bug: when two include pattens like following are added:
```
**\*.*
..\..\lib\*.*
```
The parent folder of `lib` is incorrectly included. That is because the `..` is matched by wildcard. 

## Add work around for CoreCLR issue https://github.com/dotnet/corefx/issues/616. 
The change hasn't been made into the drop yet. A warning test is added so that when the fix is in the build the test will be skipped so that a warning shows up in CI. It reminds us to revert the work around.

## Add more test cases to cover the scenario.