### PR TITLE
Process **.suffix pattern

### DIFF
--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/Patterns/PatternBuilder.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/Patterns/PatternBuilder.cs
@@ -22,6 +22,13 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.Patterns
 
             pattern = pattern.TrimStart(_slashes);
 
+            if (pattern.TrimEnd(_slashes).Length < pattern.Length)
+            {
+                // If the pattern end with a slash, it is considered as
+                // a directory.
+                pattern = pattern.TrimEnd(_slashes) + "/**";
+            }
+
             var allSegments = new List<IPathSegment>();
             var isParentSegmentLegal = true;
 

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/Patterns/PatternBuilder.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/Patterns/PatternBuilder.cs
@@ -78,6 +78,20 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.Patterns
                     }
                 }
 
+                if (segment == null && endSegment - beginSegment > 2)
+                {
+                    if (pattern[beginSegment] == '*' &&
+                        pattern[beginSegment + 1] == '*' &&
+                        pattern[beginSegment + 2] == '.')
+                    {
+                        // recognize **.
+                        // swallow the first *, add the recursive path segment and 
+                        // the remaining part will be treat as wild card in next loop.
+                        segment = new RecursiveWildcardSegment();
+                        endSegment = beginSegment;
+                    }
+                }
+
                 if (segment == null)
                 {
                     var beginsWith = string.Empty;

--- a/src/Microsoft.Framework.FileSystemGlobbing/MatcherExtensions.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/MatcherExtensions.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Framework.FileSystemGlobbing.Abstractions;
+
+namespace Microsoft.Framework.FileSystemGlobbing
+{
+    public static class MatcherExtensions
+    {
+        public static void AddExcludePatterns(this Matcher matcher, params IEnumerable<string>[] excludePatternsGroups)
+        {
+            foreach (var group in excludePatternsGroups)
+            {
+                foreach (var pattern in group)
+                {
+                    matcher.AddExclude(pattern);
+                }
+            }
+        }
+
+        public static void AddIncludePatterns(this Matcher matcher, params IEnumerable<string>[] includePatternsGroups)
+        {
+            foreach (var group in includePatternsGroups)
+            {
+                foreach (var pattern in group)
+                {
+                    matcher.AddInclude(pattern);
+                }
+            }
+        }
+
+        public static IEnumerable<string> GetResultsInFullPath(this Matcher matcher, string directoryPath)
+        {
+            var relativePaths = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(directoryPath))).Files;
+            var result = relativePaths.Select(path => Path.GetFullPath(Path.Combine(directoryPath, path))).ToArray();
+
+            return result;
+        }
+    }
+}

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/FunctionalTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/FunctionalTests.cs
@@ -132,6 +132,69 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests
                 "src/project2/compiler/shared/sub/sub/sharedsub.cs");
         }
 
+        [Fact]
+        public void RecursiveSuffixSearch()
+        {
+            var matcher = new Matcher();
+            matcher.AddInclude(@"**.txt");
+
+            ExecuteAndVerify(matcher, @"src/project",
+                "src/project/compiler/preprocess/sub/sub/preprocess-source3.txt",
+                "src/project/compiler/shared/shared1.txt",
+                "src/project/compiler/shared/sub/shared2.txt",
+                "src/project/content1.txt");
+        }
+
+        [Fact] 
+        public void FolderExclude()
+        {
+            var matcher = new Matcher();
+            matcher.AddInclude(@"**/*.*");
+            matcher.AddExclude(@"obj");
+            matcher.AddExclude(@"bin");
+            matcher.AddExclude(@".*");
+
+            ExecuteAndVerify(matcher, @"src/project",
+                "src/project/source1.cs",
+                "src/project/sub/source2.cs",
+                "src/project/sub/source3.cs",
+                "src/project/sub2/source4.cs",
+                "src/project/sub2/source5.cs",
+                "src/project/compiler/preprocess/preprocess-source1.cs",
+                "src/project/compiler/preprocess/sub/preprocess-source2.cs",
+                "src/project/compiler/preprocess/sub/sub/preprocess-source3.cs",
+                "src/project/compiler/preprocess/sub/sub/preprocess-source3.txt",
+                "src/project/compiler/shared/shared1.cs",
+                "src/project/compiler/shared/shared1.txt",
+                "src/project/compiler/shared/sub/shared2.cs",
+                "src/project/compiler/shared/sub/shared2.txt",
+                "src/project/compiler/shared/sub/sub/sharedsub.cs",
+                "src/project/compiler/resources/resource.res",
+                "src/project/compiler/resources/sub/resource2.res",
+                "src/project/compiler/resources/sub/sub/resource3.res",
+                "src/project/content1.txt");
+        }
+
+        [Fact]
+        public void FolderInclude()
+        {
+            var matcher = new Matcher();
+            matcher.AddInclude(@"compiler/");
+            ExecuteAndVerify(matcher, @"src/project",
+                "src/project/compiler/preprocess/preprocess-source1.cs",
+                "src/project/compiler/preprocess/sub/preprocess-source2.cs",
+                "src/project/compiler/preprocess/sub/sub/preprocess-source3.cs",
+                "src/project/compiler/preprocess/sub/sub/preprocess-source3.txt",
+                "src/project/compiler/shared/shared1.cs",
+                "src/project/compiler/shared/shared1.txt",
+                "src/project/compiler/shared/sub/shared2.cs",
+                "src/project/compiler/shared/sub/shared2.txt",
+                "src/project/compiler/shared/sub/sub/sharedsub.cs",
+                "src/project/compiler/resources/resource.res",
+                "src/project/compiler/resources/sub/resource2.res",
+                "src/project/compiler/resources/sub/sub/resource3.res");
+        }
+
 #if ASPNETCORE50
         [ConditionalFact]
         [RunWhenWhenDirectoryInfoWorks]

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternMatchingTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternMatchingTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests
 
         [Theory]
         [InlineData(@"", new string[] { })]
-        [InlineData(@"./", new string[] { })]
+        [InlineData(@"./", new string[] { "alpha/hello.txt", "beta/hello.txt", "gamma/hello.txt" })]
         [InlineData(@"./alpha/hello.txt", new string[] { "alpha/hello.txt" })]
         [InlineData(@"./**/hello.txt", new string[] { "alpha/hello.txt", "beta/hello.txt", "gamma/hello.txt" })]
         [InlineData(@"././**/hello.txt", new string[] { "alpha/hello.txt", "beta/hello.txt", "gamma/hello.txt" })]

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/Patterns/PatternTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/Patterns/PatternTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.Framework.FileSystemGlobbing.Internal;
+using Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments;
 using Microsoft.Framework.FileSystemGlobbing.Internal.Patterns;
 using Xunit;
 
@@ -13,13 +15,9 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
         [Theory]
         [InlineData("abc", 1)]
         [InlineData("/abc", 1)]
-        [InlineData("/abc/", 1)]
-        [InlineData("abc/", 1)]
         [InlineData("abc/efg", 2)]
-        [InlineData("abc/efg/", 2)]
         [InlineData("abc/efg/h*j", 3)]
         [InlineData("abc/efg/h*j/*.*", 4)]
-        [InlineData("abc/efg/h*j/*.*/", 4)]
         [InlineData("abc/efg/hij", 3)]
         [InlineData("abc/efg/hij/klm", 4)]
         [InlineData("../abc/efg/hij/klm", 5)]
@@ -56,19 +54,23 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
 
 
         [Theory]
+        [InlineData("/abc/", 2, 1, 0, 0)]
+        [InlineData("abc/", 2, 1, 0, 0)]
+        [InlineData("abc/efg/", 3, 2, 0, 0)]
+        [InlineData("abc/efg/h*j/*.*/", 5, 4, 0, 0)]
         [InlineData("abc/efg/**", 3, 2, 0, 0)]
         [InlineData("/abc/efg/**", 3, 2, 0, 0)]
         [InlineData("abc/efg/**/hij/klm", 5, 2, 0, 2)]
         [InlineData("abc/efg/**/hij/**/klm", 6, 2, 1, 1)]
         [InlineData("abc/efg/**/hij/**/klm/**", 7, 2, 2, 0)]
-        [InlineData("abc/efg/**/hij/**/klm/**/", 7, 2, 2, 0)]
+        [InlineData("abc/efg/**/hij/**/klm/**/", 8, 2, 2, 0)]
         [InlineData("**/hij/**/klm", 4, 0, 1, 1)]
         [InlineData("**/hij/**", 3, 0, 1, 0)]
         [InlineData("/**/hij/**", 3, 0, 1, 0)]
         [InlineData("**/**/hij/**", 4, 0, 1, 0)]
         [InlineData("ab/**/**/hij/**", 5, 1, 1, 0)]
-        [InlineData("ab/**/**/hij/**/", 5, 1, 1, 0)]
-        [InlineData("/ab/**/**/hij/**/", 5, 1, 1, 0)]
+        [InlineData("ab/**/**/hij/**/", 6, 1, 1, 0)]
+        [InlineData("/ab/**/**/hij/**/", 6, 1, 1, 0)]
         [InlineData("/ab/**/**/hij/**", 5, 1, 1, 0)]
         [InlineData("**/*.suffix", 2, 0, 0, 1)]
         [InlineData("**.suffix", 2, 0, 0, 1)]
@@ -91,13 +93,9 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
         [Theory]
         [InlineData("abc")]
         [InlineData("/abc")]
-        [InlineData("/abc/")]
-        [InlineData("abc/")]
         [InlineData("abc/efg")]
-        [InlineData("abc/efg/")]
         [InlineData("abc/efg/h*j")]
         [InlineData("abc/efg/h*j/*.*")]
-        [InlineData("abc/efg/h*j/*.*/")]
         [InlineData("abc/efg/hij")]
         [InlineData("abc/efg/hij/klm")]
         public void BuildRaggedPatternNegative(string sample)

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/Patterns/PatternTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/Patterns/PatternTests.cs
@@ -70,6 +70,9 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
         [InlineData("ab/**/**/hij/**/", 5, 1, 1, 0)]
         [InlineData("/ab/**/**/hij/**/", 5, 1, 1, 0)]
         [InlineData("/ab/**/**/hij/**", 5, 1, 1, 0)]
+        [InlineData("**/*.suffix", 2, 0, 0, 1)]
+        [InlineData("**.suffix", 2, 0, 0, 1)]
+        [InlineData("ab/**.suffix", 3, 1, 0, 1)]
         public void BuildRaggedPattern(string sample,
                              int segmentCount,
                              int startSegmentsCount,


### PR DESCRIPTION
__Includes two changes__

* Support pattern `**.suffix*`
`**.suffix` is equivalent to `**\*.suffix`. It will be translated into two path segments: a recursive path segment and a wild-card path segment.

* Support including directory by `directory\`
The patterns end with `\` or `/` will be expand to `/**/*.*`