### PR TITLE
Fix tests that were failing on Linux

### DIFF
--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/FileAbstractionsTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/FileAbstractionsTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests
         {
             using (var scenario = new DisposableFileSystem()
                 .CreateFolder("beta")
-                .CreateFile("beta\\alpha.txt"))
+                .CreateFile(Path.Combine("beta", "alpha.txt")))
             {
                 var contents1 = scenario.DirectoryInfo.EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly);
                 var beta = contents1.OfType<DirectoryInfoBase>().Single();
@@ -79,7 +79,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests
             using (var scenario = new DisposableFileSystem()
                 .CreateFolder("gamma")
                 .CreateFolder("beta")
-                .CreateFile("beta\\alpha.txt"))
+                .CreateFile(Path.Combine("beta", "alpha.txt")))
             {
                 var gamma = scenario.DirectoryInfo.GetDirectory("gamma");
                 var dotdot = gamma.GetDirectory("..");


### PR DESCRIPTION
Two file abstraction tests were failing on Linux because the paths used Windows specific path separators.