### PR TITLE
Handles '/' and '\' in PhysicalFileWatcher.IsDirectoryPath

### DIFF
--- a/src/Microsoft.AspNet.FileProviders/Implementation/PhysicalFilesWatcher.cs
+++ b/src/Microsoft.AspNet.FileProviders/Implementation/PhysicalFilesWatcher.cs
@@ -148,9 +148,7 @@ namespace Microsoft.AspNet.FileProviders
 
         private bool IsDirectoryPath(string path)
         {
-            return path != null && path.Length > 1 &&
-                (path[path.Length - 1] == Path.DirectorySeparatorChar ||
-                path[path.Length - 1] == Path.AltDirectorySeparatorChar);
+            return path != null && path.Length >= 1 && (path[path.Length - 1] == Path.DirectorySeparatorChar || path[path.Length - 1] == Path.AltDirectorySeparatorChar);
         }
 
         private string WildcardToRegexPattern(string wildcard)


### PR DESCRIPTION
@glennc based on your issue #47