### PR TITLE
Fix 101 - make all tests run on CoreCLR

### DIFF
--- a/test/Microsoft.AspNet.FileProviders.Embedded.Tests/EmbeddedFileProviderTests.cs
+++ b/test/Microsoft.AspNet.FileProviders.Embedded.Tests/EmbeddedFileProviderTests.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
-using Shouldly;
+using System.Reflection;
 using Xunit;
 
 namespace Microsoft.AspNet.FileProviders.Embedded.Tests
@@ -16,101 +16,101 @@ namespace Microsoft.AspNet.FileProviders.Embedded.Tests
         [Fact]
         public void When_GetFileInfo_and_resource_does_not_exist_then_should_not_get_file_info()
         {
-            var provider = new EmbeddedFileProvider(this.GetType().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
 
             var fileInfo = provider.GetFileInfo("DoesNotExist.Txt");
-            fileInfo.ShouldNotBe(null);
-            fileInfo.Exists.ShouldBe(false);
+            Assert.NotNull(fileInfo);
+            Assert.False(fileInfo.Exists);
         }
 
         [Fact]
         public void When_GetFileInfo_and_resource_exists_in_root_then_should_get_file_info()
         {
-            var provider = new EmbeddedFileProvider(this.GetType().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
             var expectedFileLength = new FileInfo("File.txt").Length;
             var fileInfo = provider.GetFileInfo("File.txt");
-            fileInfo.ShouldNotBe(null);
-            fileInfo.Exists.ShouldBe(true);
-            fileInfo.LastModified.ShouldNotBe(default(DateTimeOffset));
-            fileInfo.Length.ShouldBe(expectedFileLength);
-            fileInfo.IsDirectory.ShouldBe(false);
-            fileInfo.PhysicalPath.ShouldBe(null);
-            fileInfo.Name.ShouldBe("File.txt");
+            Assert.NotNull(fileInfo);
+            Assert.True(fileInfo.Exists);
+            Assert.NotEqual(default(DateTimeOffset), fileInfo.LastModified);
+            Assert.Equal(expectedFileLength, fileInfo.Length);
+            Assert.False(fileInfo.IsDirectory);
+            Assert.Null(fileInfo.PhysicalPath);
+            Assert.Equal("File.txt", fileInfo.Name);
 
             //Passing in a leading slash
             fileInfo = provider.GetFileInfo("/File.txt");
-            fileInfo.ShouldNotBe(null);
-            fileInfo.Exists.ShouldBe(true);
-            fileInfo.LastModified.ShouldNotBe(default(DateTimeOffset));
-            fileInfo.Length.ShouldBe(expectedFileLength);
-            fileInfo.IsDirectory.ShouldBe(false);
-            fileInfo.PhysicalPath.ShouldBe(null);
-            fileInfo.Name.ShouldBe("File.txt");
+            Assert.NotNull(fileInfo);
+            Assert.True(fileInfo.Exists);
+            Assert.NotEqual(default(DateTimeOffset), fileInfo.LastModified);
+            Assert.Equal(expectedFileLength, fileInfo.Length);
+            Assert.False(fileInfo.IsDirectory);
+            Assert.Null(fileInfo.PhysicalPath);
+            Assert.Equal("File.txt", fileInfo.Name);
         }
 
         [Fact]
         public void When_GetFileInfo_and_resource_exists_in_subdirectory_then_should_get_file_info()
         {
-            var provider = new EmbeddedFileProvider(this.GetType().Assembly, Namespace + ".Resources");
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".Resources");
 
             var fileInfo = provider.GetFileInfo("ResourcesInSubdirectory/File3.txt");
-            fileInfo.ShouldNotBe(null);
-            fileInfo.Exists.ShouldBe(true);
-            fileInfo.LastModified.ShouldNotBe(default(DateTimeOffset));
-            fileInfo.Length.ShouldBeGreaterThan(0);
-            fileInfo.IsDirectory.ShouldBe(false);
-            fileInfo.PhysicalPath.ShouldBe(null);
-            fileInfo.Name.ShouldBe("File3.txt");
+            Assert.NotNull(fileInfo);
+            Assert.True(fileInfo.Exists);
+            Assert.NotEqual(default(DateTimeOffset), fileInfo.LastModified);
+            Assert.True(fileInfo.Length > 0);
+            Assert.False(fileInfo.IsDirectory);
+            Assert.Null(fileInfo.PhysicalPath);
+            Assert.Equal("File3.txt", fileInfo.Name);
         }
 
         [Fact]
         public void When_GetFileInfo_and_resources_in_path_then_should_get_file_infos()
         {
-            var provider = new EmbeddedFileProvider(this.GetType().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
 
             var fileInfo = provider.GetFileInfo("Resources/File.txt");
-            fileInfo.ShouldNotBe(null);
-            fileInfo.Exists.ShouldBe(true);
-            fileInfo.LastModified.ShouldNotBe(default(DateTimeOffset));
-            fileInfo.Length.ShouldBeGreaterThan(0);
-            fileInfo.IsDirectory.ShouldBe(false);
-            fileInfo.PhysicalPath.ShouldBe(null);
-            fileInfo.Name.ShouldBe("File.txt");
+            Assert.NotNull(fileInfo);
+            Assert.True(fileInfo.Exists);
+            Assert.NotEqual(default(DateTimeOffset), fileInfo.LastModified);
+            Assert.True(fileInfo.Length > 0);
+            Assert.False(fileInfo.IsDirectory);
+            Assert.Null(fileInfo.PhysicalPath);
+            Assert.Equal("File.txt", fileInfo.Name);
         }
 
         [Fact]
         public void GetDirectoryContents()
         {
-            var provider = new EmbeddedFileProvider(this.GetType().Assembly, Namespace + ".Resources");
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".Resources");
 
             var files = provider.GetDirectoryContents("");
-            files.ShouldNotBe(null);
-            files.Count().ShouldBe(2);
-            provider.GetDirectoryContents("file").Exists.ShouldBe(false);
-            provider.GetDirectoryContents("file/").Exists.ShouldBe(false);
-            provider.GetDirectoryContents("file.txt").Exists.ShouldBe(false);
-            provider.GetDirectoryContents("file/txt").Exists.ShouldBe(false);
+            Assert.NotNull(files);
+            Assert.Equal(2, files.Count());
+            Assert.False(provider.GetDirectoryContents("file").Exists);
+            Assert.False(provider.GetDirectoryContents("file/").Exists);
+            Assert.False(provider.GetDirectoryContents("file.txt").Exists);
+            Assert.False(provider.GetDirectoryContents("file/txt").Exists);
         }
 
         [Fact]
         public void GetDirInfo_with_no_matching_base_namespace()
         {
-            var provider = new EmbeddedFileProvider(this.GetType().Assembly, "Unknown.Namespace");
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, "Unknown.Namespace");
 
             var files = provider.GetDirectoryContents(string.Empty);
-            files.ShouldNotBe(null);
-            files.Exists.ShouldBe(true);
-            files.Count().ShouldBe(0);
+            Assert.NotNull(files);
+            Assert.True(files.Exists);
+            Assert.Equal(0, files.Count());
         }
 
         [Fact]
         public void Trigger_ShouldNot_Support_Registering_Callbacks()
         {
-            var provider = new EmbeddedFileProvider(this.GetType().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
             var trigger = provider.Watch("Resources/File.txt");
-            trigger.ShouldNotBe(null);
-            trigger.ActiveExpirationCallbacks.ShouldBe(false);
-            trigger.IsExpired.ShouldBe(false);
+            Assert.NotNull(trigger);
+            Assert.False(trigger.ActiveExpirationCallbacks);
+            Assert.False(trigger.IsExpired);
         }
     }
 }

--- a/test/Microsoft.AspNet.FileProviders.Embedded.Tests/project.json
+++ b/test/Microsoft.AspNet.FileProviders.Embedded.Tests/project.json
@@ -2,7 +2,6 @@
     "dependencies": {
         "Microsoft.AspNet.FileProviders.Embedded": "1.0.0-*",
         "Microsoft.AspNet.Testing": "1.0.0-*",
-        "Shouldly": "1.1.1.1",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },
     "commands": {
@@ -10,6 +9,11 @@
     },
     "resource": "File.txt;sub/**;Resources/**",
     "frameworks": {
-        "dnx451": { }
+        "dnx451": { },
+        "dnxcore50": {
+            "dependencies": {
+                "System.Reflection.Extensions": "4.0.0-beta-*"
+            }
+        }
     }
 }

--- a/test/Microsoft.AspNet.FileProviders.Physical.Tests/project.json
+++ b/test/Microsoft.AspNet.FileProviders.Physical.Tests/project.json
@@ -2,13 +2,17 @@
     "dependencies": {
         "Microsoft.AspNet.FileProviders.Physical": "1.0.0-*",
         "Microsoft.AspNet.Testing": "1.0.0-*",
-        "Shouldly": "1.1.1.1",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },
     "commands": {
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { }
+        "dnx451": { },
+        "dnxcore50": {
+            "dependencies": {
+                "System.Threading.Tasks.Parallel": "4.0.0-beta-*"
+            }
+        }
     }
 }


### PR DESCRIPTION
Removed dependency on Shouldly (which doesn't exist on CoreCLR), and
made some other small compatibility fixes.