### PR TITLE
Enable configure the globbing comparison type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ nuget.exe
 *.sln.ide
 debugSettings.json
 project.lock.json
+/.vs/

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/IPathSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/IPathSegment.cs
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.Framework.FileSystemGlobbing.Internal
 {
     public interface IPathSegment
     {
-        bool Match(string value, StringComparison comparisonType);
+        bool Match(string value);
     }
 }

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/CurrentPathSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/CurrentPathSegment.cs
@@ -1,13 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
 {
     public class CurrentPathSegment : IPathSegment
     {
-        public bool Match(string value, StringComparison comparisonType)
+        public bool Match(string value)
         {
             return false;
         }

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/LiteralPathSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/LiteralPathSegment.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Framework.FileSystemGlobbing.Util;
 
 namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
 {
     public class LiteralPathSegment : IPathSegment
     {
-        public LiteralPathSegment(string value)
+        private readonly StringComparison _comparisonType;
+
+        public LiteralPathSegment(string value, StringComparison comparisonType)
         {
             if (value == null)
             {
@@ -15,13 +18,15 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
             }
 
             Value = value;
+
+            _comparisonType = comparisonType;
         }
 
         public string Value { get; }
 
-        public bool Match(string value, StringComparison comparisonType)
+        public bool Match(string value)
         {
-            return string.Equals(Value, value, comparisonType);
+            return string.Equals(Value, value, _comparisonType);
         }
 
         public override bool Equals(object obj)
@@ -29,12 +34,13 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
             var other = obj as LiteralPathSegment;
 
             return other != null &&
-                string.Equals(other.Value, Value, StringComparison.Ordinal);
+                _comparisonType == other._comparisonType &&
+                string.Equals(other.Value, Value, _comparisonType);
         }
 
         public override int GetHashCode()
         {
-            return Value.GetHashCode();
+            return StringComparisonHelper.GetStringComparer(_comparisonType).GetHashCode(Value);
         }
     }
 }

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/ParentPathSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/ParentPathSegment.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
     {
         private static readonly string LiteralParent = "..";
 
-        public bool Match(string value, StringComparison comparisonType)
+        public bool Match(string value)
         {
-            return string.Equals(LiteralParent, value, System.StringComparison.Ordinal);
+            return string.Equals(LiteralParent, value, StringComparison.Ordinal);
         }
     }
 }

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/RecursiveWildcardSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/RecursiveWildcardSegment.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
 {
     public class RecursiveWildcardSegment : IPathSegment
     {
-        public bool Match(string value, StringComparison comparisonType)
+        public bool Match(string value)
         {
             return false;
         }

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/WildcardPathSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/WildcardPathSegment.cs
@@ -8,13 +8,19 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
 {
     public class WildcardPathSegment : IPathSegment
     {
-        public static readonly WildcardPathSegment MatchAll = new WildcardPathSegment(string.Empty, new List<string>(), string.Empty);
+        // It doesn't matter which StringComparison type is used in this MatchAll segment because 
+        // all comparing are skipped since there is no content in the segment.
+        public static readonly WildcardPathSegment MatchAll = new WildcardPathSegment(
+            string.Empty, new List<string>(), string.Empty, StringComparison.OrdinalIgnoreCase);
 
-        public WildcardPathSegment(string beginsWith, List<string> contains, string endsWith)
+        private readonly StringComparison _comparisonType;
+
+        public WildcardPathSegment(string beginsWith, List<string> contains, string endsWith, StringComparison comparisonType)
         {
             BeginsWith = beginsWith;
             Contains = contains;
             EndsWith = endsWith;
+            _comparisonType = comparisonType;
         }
 
         public string BeginsWith { get; }
@@ -23,7 +29,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
 
         public string EndsWith { get; }
 
-        public bool Match(string value, StringComparison comparisonType)
+        public bool Match(string value)
         {
             var wildcard = this;
 
@@ -32,12 +38,12 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
                 return false;
             }
 
-            if (!value.StartsWith(wildcard.BeginsWith, comparisonType))
+            if (!value.StartsWith(wildcard.BeginsWith, _comparisonType))
             {
                 return false;
             }
 
-            if (!value.EndsWith(wildcard.EndsWith, comparisonType))
+            if (!value.EndsWith(wildcard.EndsWith, _comparisonType))
             {
                 return false;
             }
@@ -51,7 +57,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
                     value: containsValue,
                     startIndex: beginRemaining,
                     count: endRemaining - beginRemaining,
-                    comparisonType: comparisonType);
+                    comparisonType: _comparisonType);
                 if (indexOf == -1)
                 {
                     return false;

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextLinear.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextLinear.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Framework.FileSystemGlobbing.Abstractions;
 
 namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
@@ -58,7 +57,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
                 return false;
             }
 
-            return Pattern.Segments[Frame.SegmentIndex].Match(value, StringComparison.Ordinal);
+            return Pattern.Segments[Frame.SegmentIndex].Match(value);
         }
     }
 }

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextRagged.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextRagged.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
             {
                 return false;
             }
-            return Frame.SegmentGroup[Frame.SegmentIndex].Match(value, StringComparison.Ordinal);
+            return Frame.SegmentGroup[Frame.SegmentIndex].Match(value);
         }
 
         protected bool TestMatchingGroup(FileSystemInfoBase value)
@@ -124,7 +124,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
             for (int index = 0; index != groupLength; ++index)
             {
                 var segment = Frame.SegmentGroup[groupLength - index - 1];
-                if (!segment.Match(scan.Name, StringComparison.Ordinal))
+                if (!segment.Match(scan.Name))
                 {
                     return false;
                 }

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/Patterns/PatternBuilder.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/Patterns/PatternBuilder.cs
@@ -8,12 +8,24 @@ using Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts;
 
 namespace Microsoft.Framework.FileSystemGlobbing.Internal.Patterns
 {
-    public static class PatternBuilder
+    public class PatternBuilder
     {
         private static readonly char[] _slashes = new[] { '/', '\\' };
         private static readonly char[] _star = new[] { '*' };
 
-        public static IPattern Build(string pattern)
+        public PatternBuilder()
+        {
+            ComparisonType = StringComparison.OrdinalIgnoreCase;
+        }
+
+        public PatternBuilder(StringComparison comparisonType)
+        {
+            ComparisonType = comparisonType;
+        }
+
+        public StringComparison ComparisonType { get; }
+
+        public IPattern Build(string pattern)
         {
             if (pattern == null)
             {
@@ -115,7 +127,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.Patterns
                             if (endLiteral == endSegment)
                             {
                                 // and the only bit
-                                segment = new LiteralPathSegment(Portion(pattern, beginLiteral, endLiteral));
+                                segment = new LiteralPathSegment(Portion(pattern, beginLiteral, endLiteral), ComparisonType);
                             }
                             else
                             {
@@ -147,7 +159,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.Patterns
 
                     if (segment == null)
                     {
-                        segment = new WildcardPathSegment(beginsWith, contains, endsWith);
+                        segment = new WildcardPathSegment(beginsWith, contains, endsWith, ComparisonType);
                     }
                 }
 

--- a/src/Microsoft.Framework.FileSystemGlobbing/Matcher.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Matcher.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Framework.FileSystemGlobbing.Abstractions;
 using Microsoft.Framework.FileSystemGlobbing.Internal;
@@ -12,22 +13,35 @@ namespace Microsoft.Framework.FileSystemGlobbing
     {
         private IList<IPattern> _includePatterns = new List<IPattern>();
         private IList<IPattern> _excludePatterns = new List<IPattern>();
+        private readonly PatternBuilder _builder;
+        private readonly StringComparison _comparison;
+
+        public Matcher()
+            : this(StringComparison.OrdinalIgnoreCase)
+        {
+        }
+
+        public Matcher(StringComparison comparisonType)
+        {
+            _comparison = comparisonType;
+            _builder = new PatternBuilder(comparisonType);
+        }
 
         public virtual Matcher AddInclude(string pattern)
         {
-            _includePatterns.Add(PatternBuilder.Build(pattern));
+            _includePatterns.Add(_builder.Build(pattern));
             return this;
         }
 
         public virtual Matcher AddExclude(string pattern)
         {
-            _excludePatterns.Add(PatternBuilder.Build(pattern));
+            _excludePatterns.Add(_builder.Build(pattern));
             return this;
         }
 
         public virtual PatternMatchingResult Execute(DirectoryInfoBase directoryInfo)
         {
-            var context = new MatcherContext(_includePatterns, _excludePatterns, directoryInfo);
+            var context = new MatcherContext(_includePatterns, _excludePatterns, directoryInfo, _comparison);
             return context.Execute();
         }
     }

--- a/src/Microsoft.Framework.FileSystemGlobbing/Util/StringComparisonHelper.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Util/StringComparisonHelper.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Framework.FileSystemGlobbing.Util
+{
+    internal static class StringComparisonHelper
+    {
+        public static StringComparer GetStringComparer(StringComparison comparisonType)
+        {
+            switch (comparisonType)
+            {
+                case StringComparison.CurrentCulture:
+                    return StringComparer.CurrentCulture;
+                case StringComparison.CurrentCultureIgnoreCase:
+                    return StringComparer.CurrentCultureIgnoreCase;
+                case StringComparison.Ordinal:
+                    return StringComparer.Ordinal;
+                case StringComparison.OrdinalIgnoreCase:
+                    return StringComparer.OrdinalIgnoreCase;
+#if !DNXCORE50
+                case StringComparison.InvariantCulture:
+                    return StringComparer.InvariantCulture;
+                case StringComparison.InvariantCultureIgnoreCase:
+                    return StringComparer.InvariantCultureIgnoreCase;
+#endif
+                default:
+                    throw new InvalidOperationException($"Unexpected StringComparison type: {comparisonType}");
+            }
+        }
+    }
+}

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternContexts/PatternContextRaggedTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternContexts/PatternContextRaggedTests.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternContexts
         [Fact]
         public void PredictBeforeEnterDirectoryShouldThrow()
         {
-            var pattern = PatternBuilder.Build("**") as IRaggedPattern;
+            var builder = new PatternBuilder();
+            var pattern = builder.Build("**") as IRaggedPattern;
             var context = new PatternContextRaggedInclude(pattern);
 
             Assert.Throws<InvalidOperationException>(() =>
@@ -36,7 +37,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternContexts
         [InlineData("/a/b/**/c/d", new string[] { "root", "a", "b", "whatever", "anything" }, null, false)]
         public void PredictReturnsCorrectResult(string patternString, string[] pushDirectory, string expectSegment, bool expectWildcard)
         {
-            var pattern = PatternBuilder.Build(patternString) as IRaggedPattern;
+            var builder = new PatternBuilder();
+            var pattern = builder.Build(patternString) as IRaggedPattern;
             Assert.NotNull(pattern);
 
             var context = new PatternContextRaggedInclude(pattern);
@@ -64,7 +66,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternContexts
         [InlineData("/a/b/**/c/d", new string[] { "root", "a", "c" })]
         public void PredictNotCallBackWhenEnterUnmatchDirectory(string patternString, string[] pushDirectory)
         {
-            var pattern = PatternBuilder.Build(patternString) as IRaggedPattern;
+            var builder = new PatternBuilder();
+            var pattern = builder.Build(patternString) as IRaggedPattern;
             var context = new PatternContextRaggedInclude(pattern);
             PatternContextHelper.PushDirectory(context, pushDirectory);
 

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternSegments/CurrentPathSegmentTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternSegments/CurrentPathSegmentTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments;
 using Xunit;
 
@@ -10,16 +9,13 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternSegments
     public class CurrentPathSegmentTests
     {
         [Theory]
-        [InlineData("anything", StringComparison.Ordinal)]
-        [InlineData("anything", StringComparison.OrdinalIgnoreCase)]
-        [InlineData("anything", StringComparison.CurrentCulture)]
-        [InlineData("anything", StringComparison.CurrentCultureIgnoreCase)]
-        [InlineData("", StringComparison.Ordinal)]
-        [InlineData(null, StringComparison.Ordinal)]
-        public void Match(string testSample, StringComparison comparerType)
+        [InlineData("anything")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void Match(string testSample)
         {
             var pathSegment = new CurrentPathSegment();
-            Assert.False(pathSegment.Match(testSample, comparerType));
+            Assert.False(pathSegment.Match(testSample));
         }
     }
 }

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternSegments/LiteralPathSegmentTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternSegments/LiteralPathSegmentTests.cs
@@ -14,14 +14,14 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternSegments
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                var pathSegment = new LiteralPathSegment(value: null);
+                var pathSegment = new LiteralPathSegment(value: null, comparisonType: StringComparison.OrdinalIgnoreCase);
             });
         }
 
         [Fact]
         public void AllowEmptyInDefaultConstructor()
         {
-            var pathSegment = new LiteralPathSegment(string.Empty);
+            var pathSegment = new LiteralPathSegment(string.Empty, comparisonType: StringComparison.Ordinal);
             Assert.NotNull(pathSegment);
         }
 
@@ -32,11 +32,11 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternSegments
         [InlineData("something", "anything", StringComparison.OrdinalIgnoreCase, false)]
         [InlineData("something", "Something", StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("something", "something", StringComparison.OrdinalIgnoreCase, true)]
-        public void Match(string initialValue, string testSample, StringComparison comparerType, bool expectation)
+        public void Match(string initialValue, string testSample, StringComparison comparisonType, bool expectation)
         {
-            var pathSegment = new LiteralPathSegment(initialValue);
+            var pathSegment = new LiteralPathSegment(initialValue, comparisonType);
             Assert.Equal(initialValue, pathSegment.Value);
-            Assert.Equal(expectation, pathSegment.Match(testSample, comparerType));
+            Assert.Equal(expectation, pathSegment.Match(testSample));
         }
     }
 }

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternSegments/ParentPathSegmentTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternSegments/ParentPathSegmentTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments;
 using Xunit;
 
@@ -10,16 +9,13 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternSegments
     public class ParentPathSegmentTests
     {
         [Theory]
-        [InlineData(".", StringComparison.Ordinal, false)]
-        [InlineData("..", StringComparison.Ordinal, true)]
-        [InlineData("...", StringComparison.Ordinal, false)]
-        [InlineData(".", StringComparison.OrdinalIgnoreCase, false)]
-        [InlineData("..", StringComparison.OrdinalIgnoreCase, true)]
-        [InlineData("...", StringComparison.OrdinalIgnoreCase, false)]
-        public void Match(string testSample, StringComparison comparerType, bool expectation)
+        [InlineData(".", false)]
+        [InlineData("..", true)]
+        [InlineData("...", false)]
+        public void Match(string testSample, bool expectation)
         {
             var pathSegment = new ParentPathSegment();
-            Assert.Equal(expectation, pathSegment.Match(testSample, comparerType));
+            Assert.Equal(expectation, pathSegment.Match(testSample));
         }
     }
 }

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternSegments/RecursiveWildcardSegmentTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternSegments/RecursiveWildcardSegmentTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments;
 using Xunit;
 
@@ -9,13 +8,11 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternSegments
 {
     public class RecursiveWildcardSegmentTests
     {
-        [Theory]
-        [InlineData("anything", StringComparison.Ordinal)]
-        [InlineData("anything", StringComparison.OrdinalIgnoreCase)]
-        public void Match(string testSample, StringComparison comparerType)
+        [Fact]
+        public void Match()
         {
             var pathSegment = new RecursiveWildcardSegment();
-            Assert.False(pathSegment.Match(testSample, comparerType));
+            Assert.False(pathSegment.Match("Anything"));
         }
     }
 }

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternSegments/WildcardPathSegmentTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternSegments/WildcardPathSegmentTests.cs
@@ -11,14 +11,16 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternSegments
 {
     public class WildcardPathSegmentTests
     {
-        [Fact]
-        public void DefaultConstructor()
+        [Theory]
+        [InlineData(StringComparison.Ordinal)]
+        [InlineData(StringComparison.OrdinalIgnoreCase)]
+        public void DefaultConstructor(StringComparison comparisonType)
         {
             var paramBegin = "begin";
             var paramContains = new List<string> { "1", "2", "three" };
             var paramEnd = "end";
 
-            var segment = new WildcardPathSegment(paramBegin, paramContains, paramEnd);
+            var segment = new WildcardPathSegment(paramBegin, paramContains, paramEnd, comparisonType);
 
             Assert.Equal(paramBegin, segment.BeginsWith);
             Assert.Equal<string>(paramContains, segment.Contains);
@@ -31,17 +33,17 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternSegments
         {
             var wildcardPathSegment = (WildcardPathSegment)segment;
             Assert.True(
-                wildcardPathSegment.Match(testSample, StringComparison.OrdinalIgnoreCase),
+                wildcardPathSegment.Match(testSample),
                 string.Format("[TestSample: {0}] [Wildcard: {1}]", testSample, Serialize(wildcardPathSegment)));
         }
 
         [Theory]
-        [MemberData("GetNegativeOrdinalCaseDataSample")]
+        [MemberData("GetNegativeOrdinalIgnoreCaseDataSample")]
         public void NegativeOrdinalIgnoreCaseMatch(string testSample, object segment)
         {
             var wildcardPathSegment = (WildcardPathSegment)segment;
             Assert.False(
-                wildcardPathSegment.Match(testSample, StringComparison.OrdinalIgnoreCase),
+                wildcardPathSegment.Match(testSample),
                 string.Format("[TestSample: {0}] [Wildcard: {1}]", testSample, Serialize(wildcardPathSegment)));
         }
 
@@ -51,7 +53,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternSegments
         {
             var wildcardPathSegment = (WildcardPathSegment)segment;
             Assert.True(
-                wildcardPathSegment.Match(testSample, StringComparison.Ordinal),
+                wildcardPathSegment.Match(testSample),
                 string.Format("[TestSample: {0}] [Wildcard: {1}]", testSample, Serialize(wildcardPathSegment)));
         }
 
@@ -61,85 +63,85 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternSegments
         {
             var wildcardPathSegment = (WildcardPathSegment)segment;
             Assert.False(
-                wildcardPathSegment.Match(testSample, StringComparison.Ordinal),
+                wildcardPathSegment.Match(testSample),
                 string.Format("[TestSample: {0}] [Wildcard: {1}]", testSample, Serialize(wildcardPathSegment)));
         }
 
         public static IEnumerable<object[]> GetPositiveOrdinalIgnoreCaseDataSample()
         {
-            yield return WrapResult("abc", "a", "c");
-            yield return WrapResult("abBb123c", "a", "c");
-            yield return WrapResult("aaac", "a", "c");
-            yield return WrapResult("acccc", "a", "c");
-            yield return WrapResult("aacc", "a", "c");
-            yield return WrapResult("aacc", "aa", "c");
-            yield return WrapResult("acc", "ac", "c");
-            yield return WrapResult("abcdefgh", "ab", "cd", "ef", "gh");
-            yield return WrapResult("abCDEfgh", "ab", "cd", "ef", "gh");
-            yield return WrapResult("ab123cd321ef123gh", "ab", "cd", "ef", "gh");
-            yield return WrapResult("abcd321ef123gh", "ab", "cd", "ef", "gh");
-            yield return WrapResult("ababcd321ef123gh", "ab", "cd", "ef", "gh");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "abc", "a", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "abBb123c", "a", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "aaac", "a", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "acccc", "a", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "aacc", "a", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "aacc", "aa", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "acc", "ac", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "abcdefgh", "ab", "cd", "ef", "gh");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "abCDEfgh", "ab", "cd", "ef", "gh");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "ab123cd321ef123gh", "ab", "cd", "ef", "gh");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "abcd321ef123gh", "ab", "cd", "ef", "gh");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "ababcd321ef123gh", "ab", "cd", "ef", "gh");
         }
 
-        public static IEnumerable<object[]> GetNegativeOrdinalCaseDataSample()
+        public static IEnumerable<object[]> GetNegativeOrdinalIgnoreCaseDataSample()
         {
-            yield return WrapResult("aa", "a", "c");
-            yield return WrapResult("cc", "a", "c");
-            yield return WrapResult("ab", "a", "c");
-            yield return WrapResult("ab", "a", "b", "c");
-            yield return WrapResult("bc", "a", "b", "c");
-            yield return WrapResult("ac", "a", "b", "c");
-            yield return WrapResult("abc", "a", "b", "b", "c");
-            yield return WrapResult("ab", "ab", "c");
-            yield return WrapResult("ab", "abb", "c");
-            yield return WrapResult("ac", "ac", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "aa", "a", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "cc", "a", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "ab", "a", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "ab", "a", "b", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "bc", "a", "b", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "ac", "a", "b", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "abc", "a", "b", "b", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "ab", "ab", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "ab", "abb", "c");
+            yield return WrapResult(StringComparison.OrdinalIgnoreCase, "ac", "ac", "c");
         }
 
         public static IEnumerable<object[]> GetPositiveOrdinalDataSample()
         {
-            yield return WrapResult("abc", "a", "c");
-            yield return WrapResult("abBb123c", "a", "c");
-            yield return WrapResult("aaac", "a", "c");
-            yield return WrapResult("Aaac", "A", "c");
-            yield return WrapResult("acccC", "a", "C");
-            yield return WrapResult("aacc", "a", "c");
-            yield return WrapResult("aAcc", "aA", "c");
-            yield return WrapResult("acc", "ac", "c");
-            yield return WrapResult("abcDefgh", "ab", "cD", "ef", "gh");
-            yield return WrapResult("aB123cd321ef123gh", "aB", "cd", "ef", "gh");
-            yield return WrapResult("abcd321ef123gh", "ab", "cd", "ef", "gh");
-            yield return WrapResult("ababcdCD321ef123gh", "ab", "cd", "ef", "gh");
-            yield return WrapResult("ababcdCD321ef123gh", "ab", "CD", "ef", "gh");
-            yield return WrapResult("ababcd321eF123gh", "ab", "cd", "eF", "gh");
+            yield return WrapResult(StringComparison.Ordinal, "abc", "a", "c");
+            yield return WrapResult(StringComparison.Ordinal, "abBb123c", "a", "c");
+            yield return WrapResult(StringComparison.Ordinal, "aaac", "a", "c");
+            yield return WrapResult(StringComparison.Ordinal, "Aaac", "A", "c");
+            yield return WrapResult(StringComparison.Ordinal, "acccC", "a", "C");
+            yield return WrapResult(StringComparison.Ordinal, "aacc", "a", "c");
+            yield return WrapResult(StringComparison.Ordinal, "aAcc", "aA", "c");
+            yield return WrapResult(StringComparison.Ordinal, "acc", "ac", "c");
+            yield return WrapResult(StringComparison.Ordinal, "abcDefgh", "ab", "cD", "ef", "gh");
+            yield return WrapResult(StringComparison.Ordinal, "aB123cd321ef123gh", "aB", "cd", "ef", "gh");
+            yield return WrapResult(StringComparison.Ordinal, "abcd321ef123gh", "ab", "cd", "ef", "gh");
+            yield return WrapResult(StringComparison.Ordinal, "ababcdCD321ef123gh", "ab", "cd", "ef", "gh");
+            yield return WrapResult(StringComparison.Ordinal, "ababcdCD321ef123gh", "ab", "CD", "ef", "gh");
+            yield return WrapResult(StringComparison.Ordinal, "ababcd321eF123gh", "ab", "cd", "eF", "gh");
         }
 
         public static IEnumerable<object[]> GetNegativeOrdinalDataSample()
         {
-            yield return WrapResult("aa", "a", "c");
-            yield return WrapResult("abc", "A", "c");
-            yield return WrapResult("cc", "a", "c");
-            yield return WrapResult("ab", "a", "c");
-            yield return WrapResult("ab", "a", "b", "c");
-            yield return WrapResult("bc", "a", "b", "c");
-            yield return WrapResult("ac", "a", "b", "c");
-            yield return WrapResult("abc", "a", "b", "b", "c");
-            yield return WrapResult("ab", "ab", "c");
-            yield return WrapResult("ab", "abb", "c");
-            yield return WrapResult("ac", "ac", "c");
-            yield return WrapResult("abBb123C", "a", "c");
-            yield return WrapResult("Aaac", "a", "c");
-            yield return WrapResult("aAac", "A", "c");
-            yield return WrapResult("aCc", "a", "C");
-            yield return WrapResult("aacc", "aA", "c");
-            yield return WrapResult("acc", "aC", "c");
-            yield return WrapResult("abcDefgh", "ab", "cd", "ef", "gh");
-            yield return WrapResult("aB123cd321ef123gh", "aB", "cd", "EF", "gh");
-            yield return WrapResult("abcd321ef123gh", "ab", "cd", "efF", "gh");
-            yield return WrapResult("ababcdCD321ef123gh", "AB", "cd", "ef", "gh");
-            yield return WrapResult("ababcdCD321ef123gh", "ab", "CD", "EF", "gh");
+            yield return WrapResult(StringComparison.Ordinal, "aa", "a", "c");
+            yield return WrapResult(StringComparison.Ordinal, "abc", "A", "c");
+            yield return WrapResult(StringComparison.Ordinal, "cc", "a", "c");
+            yield return WrapResult(StringComparison.Ordinal, "ab", "a", "c");
+            yield return WrapResult(StringComparison.Ordinal, "ab", "a", "b", "c");
+            yield return WrapResult(StringComparison.Ordinal, "bc", "a", "b", "c");
+            yield return WrapResult(StringComparison.Ordinal, "ac", "a", "b", "c");
+            yield return WrapResult(StringComparison.Ordinal, "abc", "a", "b", "b", "c");
+            yield return WrapResult(StringComparison.Ordinal, "ab", "ab", "c");
+            yield return WrapResult(StringComparison.Ordinal, "ab", "abb", "c");
+            yield return WrapResult(StringComparison.Ordinal, "ac", "ac", "c");
+            yield return WrapResult(StringComparison.Ordinal, "abBb123C", "a", "c");
+            yield return WrapResult(StringComparison.Ordinal, "Aaac", "a", "c");
+            yield return WrapResult(StringComparison.Ordinal, "aAac", "A", "c");
+            yield return WrapResult(StringComparison.Ordinal, "aCc", "a", "C");
+            yield return WrapResult(StringComparison.Ordinal, "aacc", "aA", "c");
+            yield return WrapResult(StringComparison.Ordinal, "acc", "aC", "c");
+            yield return WrapResult(StringComparison.Ordinal, "abcDefgh", "ab", "cd", "ef", "gh");
+            yield return WrapResult(StringComparison.Ordinal, "aB123cd321ef123gh", "aB", "cd", "EF", "gh");
+            yield return WrapResult(StringComparison.Ordinal, "abcd321ef123gh", "ab", "cd", "efF", "gh");
+            yield return WrapResult(StringComparison.Ordinal, "ababcdCD321ef123gh", "AB", "cd", "ef", "gh");
+            yield return WrapResult(StringComparison.Ordinal, "ababcdCD321ef123gh", "ab", "CD", "EF", "gh");
         }
 
-        private static object[] WrapResult(params string[] values)
+        private static object[] WrapResult(StringComparison comparisonType, params string[] values)
         {
             if (values == null || values.Length < 3)
             {
@@ -150,7 +152,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternSegments
             var endWith = values[values.Length - 1];
             var contains = values.Skip(2).Take(values.Length - 3);
 
-            return new object[] { values[0], new WildcardPathSegment(beginWith, contains.ToList(), endWith) };
+            return new object[] { values[0], new WildcardPathSegment(beginWith, contains.ToList(), endWith, comparisonType) };
         }
 
         private static string Serialize(WildcardPathSegment segment)

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/Patterns/PatternTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/Patterns/PatternTests.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using Microsoft.Framework.FileSystemGlobbing.Internal;
-using Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments;
 using Microsoft.Framework.FileSystemGlobbing.Internal.Patterns;
 using Xunit;
 
@@ -24,7 +22,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
         [InlineData("../../abc/efg/hij/klm", 6)]
         public void BuildLinearPattern(string sample, int segmentCount)
         {
-            var pattern = PatternBuilder.Build(sample);
+            var builder = new PatternBuilder();
+            var pattern = builder.Build(sample);
 
             Assert.True(pattern is ILinearPattern);
             Assert.Equal(segmentCount, (pattern as ILinearPattern).Segments.Count);
@@ -47,7 +46,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
         [InlineData("/ab/**/**/hij/**")]
         public void BuildLinearPatternNegative(string sample)
         {
-            var pattern = PatternBuilder.Build(sample) as ILinearPattern;
+            var builder = new PatternBuilder();
+            var pattern = builder.Build(sample) as ILinearPattern;
 
             Assert.Null(pattern);
         }
@@ -81,7 +81,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
                              int containSegmentCount,
                              int endSegmentCount)
         {
-            var pattern = PatternBuilder.Build(sample) as IRaggedPattern;
+            var builder = new PatternBuilder();
+            var pattern = builder.Build(sample) as IRaggedPattern;
 
             Assert.NotNull(pattern);
             Assert.Equal(segmentCount, pattern.Segments.Count);
@@ -100,7 +101,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
         [InlineData("abc/efg/hij/klm")]
         public void BuildRaggedPatternNegative(string sample)
         {
-            var pattern = PatternBuilder.Build(sample) as IRaggedPattern;
+            var builder = new PatternBuilder();
+            var pattern = builder.Build(sample) as IRaggedPattern;
 
             Assert.Null(pattern);
         }
@@ -115,8 +117,10 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
         public void ThrowExceptionForInvalidParentsPath(string sample)
         {
             // parent segment is only allowed at the beginning of the pattern
-            Assert.Throws<ArgumentException>(() => {
-                var pattern = PatternBuilder.Build(sample);
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var builder = new PatternBuilder();
+                var pattern = builder.Build(sample);
 
                 Assert.Null(pattern);
             });
@@ -125,8 +129,10 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.Patterns
         [Fact]
         public void ThrowExceptionForNull()
         {
-            Assert.Throws<ArgumentNullException>(() => {
-                PatternBuilder.Build(null);
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var builder = new PatternBuilder();
+                builder.Build(null);
             });
         }
     }

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/MockNonRecursivePathSegment.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/MockNonRecursivePathSegment.cs
@@ -8,6 +8,13 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternContexts
 {
     internal class MockNonRecursivePathSegment : IPathSegment
     {
+        private readonly StringComparison _comparisonType;
+
+        public MockNonRecursivePathSegment(StringComparison comparisonType)
+        {
+            _comparisonType = comparisonType;
+        }
+
         public MockNonRecursivePathSegment(string value)
         {
             Value = value;
@@ -15,9 +22,9 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternContexts
 
         public string Value { get; }
 
-        public bool Match(string value, StringComparison comparisonType)
+        public bool Match(string value)
         {
-            return string.Compare(Value, value, comparisonType) == 0;
+            return string.Compare(Value, value, _comparisonType) == 0;
         }
     }
 }

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/MockRecursivePathSegment.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/MockRecursivePathSegment.cs
@@ -8,11 +8,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternContexts
 {
     internal class MockRecursivePathSegment : IPathSegment
     {
-        public MockRecursivePathSegment()
-        {
-        }
-
-        public bool Match(string value, StringComparison comparisonType)
+        public bool Match(string value)
         {
             return false;
         }


### PR DESCRIPTION
This change enable the consumer of globbing to configure the string comparison type. It is done by create a `Matcher` with specified `StringComparison` value.

Internally some refactory is done to achieve the goal:
1. `IPathSegment` interface doesn't requires a `StringComparison` for `Match` function. Three out of the five implementations of this interface didn't use this value.
2. The comparison type is decided when `PathSegment` are created instead of at execution time. Benefit of doing this is to simplify the code: the comparison type doesn't need to be passed down from method to method.
3. `PathBuilder` is not a static class any more. Because it nows hold on the value of comparison type.
4. Default comparison type is case-insensitive.

Tests are updated accordingly and the new tests are added to cover both cases.

Related: https://github.com/aspnet/dnx/issues/1645

/review: @davidfowl @Tratcher @victorhurdugaci 
/cc: @muratg @lodejard @pranavkm 