### PR TITLE
teach Matcher to return Stems for matches

### DIFF
--- a/src/Microsoft.Framework.FileSystemGlobbing/FilePatternMatch.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/FilePatternMatch.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.Framework.FileSystemGlobbing
+{
+    public struct FilePatternMatch : IEquatable<FilePatternMatch>
+    {
+        public string Path { get; }
+        public string Stem { get; }
+
+        public FilePatternMatch(string path, string stem)
+        {
+            Path = path;
+            Stem = stem;
+        }
+
+        public bool Equals(FilePatternMatch other)
+        {
+            return string.Equals(other.Path, Path, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(other.Stem, Stem, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals((FilePatternMatch)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCodeCombiner.Start()
+                .Add(Path)
+                .Add(Stem)
+                .CombinedHash;
+        }
+    }
+}

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/IPathSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/IPathSegment.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal
 {
     public interface IPathSegment
     {
+        bool CanProduceStem { get; }
+
         bool Match(string value);
     }
 }

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/IPatternContext.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/IPatternContext.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal
 
         bool Test(DirectoryInfoBase directory);
 
-        bool Test(FileInfoBase file);
+        PatternTestResult Test(FileInfoBase file);
 
         void PushDirectory(DirectoryInfoBase directory);
 

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/CurrentPathSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/CurrentPathSegment.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
 {
     public class CurrentPathSegment : IPathSegment
     {
+        public bool CanProduceStem { get { return false; } }
+
         public bool Match(string value)
         {
             return false;

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/LiteralPathSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/LiteralPathSegment.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
     {
         private readonly StringComparison _comparisonType;
 
+        public bool CanProduceStem { get { return false; } }
+
         public LiteralPathSegment(string value, StringComparison comparisonType)
         {
             if (value == null)

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/ParentPathSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/ParentPathSegment.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
     {
         private static readonly string LiteralParent = "..";
 
+        public bool CanProduceStem { get { return false; } }
+
         public bool Match(string value)
         {
             return string.Equals(LiteralParent, value, StringComparison.Ordinal);

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/RecursiveWildcardSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/RecursiveWildcardSegment.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
 {
     public class RecursiveWildcardSegment : IPathSegment
     {
+        public bool CanProduceStem { get { return true; } }
+
         public bool Match(string value)
         {
             return false;

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/WildcardPathSegment.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PathSegments/WildcardPathSegment.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PathSegments
             _comparisonType = comparisonType;
         }
 
+        public bool CanProduceStem { get { return true; } }
+
         public string BeginsWith { get; }
 
         public List<string> Contains { get; }

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContext.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContext.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
 
         public virtual void Declare(Action<IPathSegment, bool> declare) { }
 
-        public abstract bool Test(FileInfoBase file);
+        public abstract PatternTestResult Test(FileInfoBase file);
 
         public abstract bool Test(DirectoryInfoBase directory);
 

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextLinear.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextLinear.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.Framework.FileSystemGlobbing.Abstractions;
 
 namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
@@ -11,6 +13,21 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
         public PatternContextLinear(ILinearPattern pattern)
         {
             Pattern = pattern;
+        }
+
+        public override PatternTestResult Test(FileInfoBase file)
+        {
+            if (IsStackEmpty())
+            {
+                throw new InvalidOperationException("Can't test file before entering a directory.");
+            }
+
+            if(!Frame.IsNotApplicable && IsLastSegment() && TestMatchingSegment(file.Name))
+            {
+                return PatternTestResult.Success(CalculateStem(file));
+            }
+
+            return PatternTestResult.Failed;
         }
 
         public override void PushDirectory(DirectoryInfoBase directory)
@@ -30,6 +47,14 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
             }
             else
             {
+                // Determine this frame's contribution to the stem (if any)
+                var segment = Pattern.Segments[Frame.SegmentIndex];
+                if (frame.InStem || segment.CanProduceStem)
+                {
+                    frame.InStem = true;
+                    frame.StemItems.Add(directory.Name);
+                }
+
                 // directory matches segment, advance position in pattern
                 frame.SegmentIndex = frame.SegmentIndex + 1;
             }
@@ -41,6 +66,18 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
         {
             public bool IsNotApplicable;
             public int SegmentIndex;
+            public bool InStem;
+            private IList<string> _stemItems;
+
+            public IList<string> StemItems
+            {
+                get { return _stemItems ?? (_stemItems = new List<string>()); }
+            }
+
+            public string Stem
+            {
+                get { return _stemItems == null ? null : string.Join("/", _stemItems); }
+            }
         }
 
         protected ILinearPattern Pattern { get; }
@@ -58,6 +95,11 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
             }
 
             return Pattern.Segments[Frame.SegmentIndex].Match(value);
+        }
+
+        protected string CalculateStem(FileInfoBase matchedFile)
+        {
+            return MatcherContext.CombinePath(Frame.Stem, matchedFile.Name);
         }
     }
 }

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextLinearExclude.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextLinearExclude.cs
@@ -13,26 +13,11 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
         {
         }
 
-        public override bool Test(FileInfoBase file)
-        {
-            if (IsStackEmpty())
-            {
-                throw new InvalidOperationException("Can't test file before enters any directory.");
-            }
-
-            if (Frame.IsNotApplicable)
-            {
-                return false;
-            }
-
-            return IsLastSegment() && TestMatchingSegment(file.Name);
-        }
-
         public override bool Test(DirectoryInfoBase directory)
         {
             if (IsStackEmpty())
             {
-                throw new InvalidOperationException("Can't test directory before enters any directory.");
+                throw new InvalidOperationException("Can't test directory before entering a directory.");
             }
 
             if (Frame.IsNotApplicable)

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextLinearInclude.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextLinearInclude.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
         {
             if (IsStackEmpty())
             {
-                throw new InvalidOperationException("Can't declare path segment before enters any directory.");
+                throw new InvalidOperationException("Can't declare path segment before entering a directory.");
             }
 
             if (Frame.IsNotApplicable)
@@ -31,26 +31,11 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
             }
         }
 
-        public override bool Test(FileInfoBase file)
-        {
-            if (IsStackEmpty())
-            {
-                throw new InvalidOperationException("Can't test file before enters any directory.");
-            }
-
-            if (Frame.IsNotApplicable)
-            {
-                return false;
-            }
-
-            return IsLastSegment() && TestMatchingSegment(file.Name);
-        }
-
         public override bool Test(DirectoryInfoBase directory)
         {
             if (IsStackEmpty())
             {
-                throw new InvalidOperationException("Can't test directory before enters any directory.");
+                throw new InvalidOperationException("Can't test directory before entering a directory.");
             }
 
             if (Frame.IsNotApplicable)

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextRaggedExclude.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextRaggedExclude.cs
@@ -13,26 +13,11 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
         {
         }
 
-        public override bool Test(FileInfoBase file)
-        {
-            if (IsStackEmpty())
-            {
-                throw new InvalidOperationException("Can't test file before enters any directory.");
-            }
-
-            if (Frame.IsNotApplicable)
-            {
-                return false;
-            }
-
-            return IsEndingGroup() && TestMatchingGroup(file);
-        }
-
         public override bool Test(DirectoryInfoBase directory)
         {
             if (IsStackEmpty())
             {
-                throw new InvalidOperationException("Can't test directory before enters any directory.");
+                throw new InvalidOperationException("Can't test directory before entering a directory.");
             }
 
             if (Frame.IsNotApplicable)

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextRaggedInclude.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternContexts/PatternContextRaggedInclude.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
         {
             if (IsStackEmpty())
             {
-                throw new InvalidOperationException("Can't declare path segment before enters any directory.");
+                throw new InvalidOperationException("Can't declare path segment before entering a directory.");
             }
 
             if (Frame.IsNotApplicable)
@@ -36,26 +36,11 @@ namespace Microsoft.Framework.FileSystemGlobbing.Internal.PatternContexts
             }
         }
 
-        public override bool Test(FileInfoBase file)
-        {
-            if (IsStackEmpty())
-            {
-                throw new InvalidOperationException("Can't test file before enters any directory.");
-            }
-
-            if (Frame.IsNotApplicable)
-            {
-                return false;
-            }
-
-            return IsEndingGroup() && TestMatchingGroup(file);
-        }
-
         public override bool Test(DirectoryInfoBase directory)
         {
             if (IsStackEmpty())
             {
-                throw new InvalidOperationException("Can't test directory before enters any directory.");
+                throw new InvalidOperationException("Can't test directory before entering a directory.");
             }
 
             if (Frame.IsNotApplicable)

--- a/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternTestResult.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/Internal/PatternTestResult.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.FileSystemGlobbing.Internal
+{
+    public struct PatternTestResult
+    {
+        public static readonly PatternTestResult Failed = new PatternTestResult(isSuccessful: false, stem: null);
+
+        public bool IsSuccessful { get; }
+        public string Stem { get; }
+
+        private PatternTestResult(bool isSuccessful, string stem)
+        {
+            IsSuccessful = isSuccessful;
+            Stem = stem;
+        }
+
+        public static PatternTestResult Success(string stem)
+        {
+            return new PatternTestResult(isSuccessful: true, stem: stem);
+        }
+    }
+}

--- a/src/Microsoft.Framework.FileSystemGlobbing/MatcherExtensions.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/MatcherExtensions.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Framework.FileSystemGlobbing
 
         public static IEnumerable<string> GetResultsInFullPath(this Matcher matcher, string directoryPath)
         {
-            var relativePaths = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(directoryPath))).Files;
-            var result = relativePaths.Select(path => Path.GetFullPath(Path.Combine(directoryPath, path))).ToArray();
+            var matches = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(directoryPath))).Files;
+            var result = matches.Select(match => Path.GetFullPath(Path.Combine(directoryPath, match.Path))).ToArray();
 
             return result;
         }

--- a/src/Microsoft.Framework.FileSystemGlobbing/PatternMatchingResult.cs
+++ b/src/Microsoft.Framework.FileSystemGlobbing/PatternMatchingResult.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Framework.FileSystemGlobbing
 {
     public class PatternMatchingResult
     {
-        public PatternMatchingResult(IEnumerable<string> files)
+        public PatternMatchingResult(IEnumerable<FilePatternMatch> files)
         {
             Files = files;
         }
 
-        public IEnumerable<string> Files { get; set; }
+        public IEnumerable<FilePatternMatch> Files { get; set; }
     }
 }

--- a/src/Microsoft.Framework.FileSystemGlobbing/project.json
+++ b/src/Microsoft.Framework.FileSystemGlobbing/project.json
@@ -6,6 +6,7 @@
         "url": "git://github.com/aspnet/filesystem"
     },
     "dependencies": {
+        "Microsoft.Framework.HashCodeCombiner.Sources": { "version": "1.0.0-*", "type": "build" }
     },
     "frameworks": {
         "net45": { },

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/FunctionalTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/FunctionalTests.cs
@@ -404,7 +404,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests
             directoryPath = Path.Combine(_context.RootPath, directoryPath);
             var results = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(directoryPath)));
 
-            var actual = results.Files.Select(relativePath => Path.GetFullPath(Path.Combine(_context.RootPath, directoryPath, relativePath)));
+            var actual = results.Files.Select(match => Path.GetFullPath(Path.Combine(_context.RootPath, directoryPath, match.Path)));
             var expect = expectFiles.Select(relativePath => Path.GetFullPath(Path.Combine(_context.RootPath, relativePath)));
 
             AssertHelpers.SortAndEqual(expect, actual, StringComparer.OrdinalIgnoreCase);

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternContexts/PatternContextLinearTests.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/PatternContexts/PatternContextLinearTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternContexts
 
             var result = context.Test(new FakeFileInfo(filename));
 
-            Assert.Equal(expectResult, result);
+            Assert.Equal(expectResult, result.IsSuccessful);
         }
 
         [Theory]
@@ -96,7 +96,7 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternContexts
 
             var result = context.Test(new FakeFileInfo(filename));
 
-            Assert.Equal(expectResult, result);
+            Assert.Equal(expectResult, result.IsSuccessful);
         }
 
         [Theory]

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/FileSystemGlobbingTestContext.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/FileSystemGlobbingTestContext.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.TestUtility
         private readonly Matcher _patternMatching;
 
         private MockDirectoryInfo _directoryInfo;
-        private PatternMatchingResult _result;
+
+        public PatternMatchingResult Result { get; private set; }
 
         public FileSystemGlobbingTestContext(string basePath, Matcher matcher)
         {
@@ -63,14 +64,14 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.TestUtility
 
         public FileSystemGlobbingTestContext Execute()
         {
-            _result = _patternMatching.Execute(_directoryInfo);
+            Result = _patternMatching.Execute(_directoryInfo);
 
             return this;
         }
 
         public FileSystemGlobbingTestContext AssertExact(params string[] files)
         {
-            Assert.Equal(files.OrderBy(file => file), _result.Files.OrderBy(file => file));
+            Assert.Equal(files.OrderBy(file => file), Result.Files.OrderBy(file => file.Path).Select(file => file.Path));
 
             return this;
         }

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/MockNonRecursivePathSegment.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/MockNonRecursivePathSegment.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternContexts
             Value = value;
         }
 
+        public bool CanProduceStem { get { return false; } }
+
         public string Value { get; }
 
         public bool Match(string value)

--- a/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/MockRecursivePathSegment.cs
+++ b/test/Microsoft.Framework.FileSystemGlobbing.Tests/TestUtility/MockRecursivePathSegment.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Framework.FileSystemGlobbing.Tests.PatternContexts
 {
     internal class MockRecursivePathSegment : IPathSegment
     {
+        public bool CanProduceStem {  get { return false; } }
+
         public bool Match(string value)
         {
             return false;


### PR DESCRIPTION
This is a pre-req for work on aspnet/dnx#848

The "stem" of a match is the part of the path matched from the first wildcard on. Or, if no wildcards are present, the simple name of the file. For example:

| Pattern | Match | Stem |
| ---------| -------- | ------ |
| `tools/install.ps1` | `tools/install.ps1` | `install.ps1` |
| `tools/*.ps1` | `tools/install.ps1` | `install.ps1` |
| `tools/**/*.ps1` | `tools/sub1/sub2/sub3/install.ps1` | `sub/sub1/sub2/sub3/install.ps1` |
| `a/b/**/c/**/*.txt` | `a/b/x/y/c/z/d.txt` | `x/y/c/z/d.txt`|

/cc @lodejard @davidfowl @troydai 