### PR TITLE
Fix/refactor some PhysicalFileProvider tests.

### DIFF
--- a/src/Microsoft.AspNet.FileProviders.Physical/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.AspNet.FileProviders.Physical/Properties/AssemblyInfo.cs
@@ -3,6 +3,8 @@
 
 using System.Reflection;
 using System.Resources;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: NeutralResourcesLanguage("en-us")]
+[assembly: InternalsVisibleTo("Microsoft.AspNet.FileProviders.Physical.Tests")]


### PR DESCRIPTION
- Split tests that were testing multiple inputs into smaller tests
- Skip .Watch() absolute path test on *nix

#134 