### PR TITLE
Wait after directory creation to avoid race condition.

### DIFF
--- a/test/Microsoft.AspNet.FileProviders.Physical.Tests/PhysicalFileProviderTests.cs
+++ b/test/Microsoft.AspNet.FileProviders.Physical.Tests/PhysicalFileProviderTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.FileProviders
     {
         private const int WaitTimeForTokenToFire = 2 * 100;
 
-        // See https://github.com/dotnet/corefx/blob/master/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs#L13
+        // See https://github.com/dotnet/corefx/blob/750602b098ceef5aa11ab626bdb359980dd1aa02/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs#L13
         private const int WaitTimeAfterDirectoryCreation = 2 * 100;
 
         [Fact]


### PR DESCRIPTION
See https://github.com/dotnet/corefx/blob/master/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs#L13.

Some tests were very flaky on Linux because they acted on directories that had just been created. Introducing a delay after directory creation made the tests stable.

I did have to skip Token_Fired_On_Directory_Name_Change though, since it's flaky after the directory is renamed. Introducing a delay didn't help there.