### PR TITLE
Change NoopChangeToken.RegisterChangeCallback to not throw exception

### DIFF
--- a/src/Microsoft.AspNet.FileProviders.Composite/CompositeFileChangeToken.cs
+++ b/src/Microsoft.AspNet.FileProviders.Composite/CompositeFileChangeToken.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.FileProviders
         /// <param name="changeTokens">The list of <see cref="IChangeToken"/> to compose.</param>
         public CompositeFileChangeToken(IList<IChangeToken> changeTokens)
         {
-            if(changeTokens == null)
+            if (changeTokens == null)
             {
                 throw new ArgumentNullException(nameof(changeTokens));
             }
@@ -34,11 +34,8 @@ namespace Microsoft.AspNet.FileProviders
             for (var i = 0; i < _changeTokens.Count; i++)
             {
                 var changeToken = _changeTokens[i];
-                if (changeToken.ActiveChangeCallbacks)
-                {
-                    var disposable = _changeTokens[i].RegisterChangeCallback(callback, state);
-                    disposables.Add(disposable);
-                }
+                var disposable = _changeTokens[i].RegisterChangeCallback(callback, state);
+                disposables.Add(disposable);
             }
             return new CompositeDisposable(disposables);
         }

--- a/src/Microsoft.AspNet.FileProviders.Sources/Implementation/EmptyDisposable.cs
+++ b/src/Microsoft.AspNet.FileProviders.Sources/Implementation/EmptyDisposable.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AspNet.FileProviders
     internal class EmptyDisposable : IDisposable
     {
         public static EmptyDisposable Instance { get; } = new EmptyDisposable();
+
         private EmptyDisposable()
         {
 

--- a/src/Microsoft.AspNet.FileProviders.Sources/Implementation/EmptyDisposable.cs
+++ b/src/Microsoft.AspNet.FileProviders.Sources/Implementation/EmptyDisposable.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.FileProviders
+{
+    internal class EmptyDisposable : IDisposable
+    {
+        public static EmptyDisposable Instance { get; } = new EmptyDisposable();
+        private EmptyDisposable()
+        {
+
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNet.FileProviders.Sources/Implementation/EmptyDisposable.cs
+++ b/src/Microsoft.AspNet.FileProviders.Sources/Implementation/EmptyDisposable.cs
@@ -11,7 +11,6 @@ namespace Microsoft.AspNet.FileProviders
 
         private EmptyDisposable()
         {
-
         }
 
         public void Dispose()

--- a/src/Microsoft.AspNet.FileProviders.Sources/Implementation/NoopChangeToken.cs
+++ b/src/Microsoft.AspNet.FileProviders.Sources/Implementation/NoopChangeToken.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.FileProviders
 
         public IDisposable RegisterChangeCallback(Action<object> callback, object state)
         {
-            throw new NotSupportedException("Trigger does not support registering change notifications.");
+            return EmptyDisposable.Instance;
         }
     }
 }

--- a/test/Microsoft.AspNet.FileProviders.Composite.Tests/CompositeFileProviderTests.cs
+++ b/test/Microsoft.AspNet.FileProviders.Composite.Tests/CompositeFileProviderTests.cs
@@ -266,7 +266,7 @@ namespace Microsoft.AspNet.FileProviders.Composite.Tests
             // Arrange
             var firstChangeToken = new MockChangeToken { ActiveChangeCallbacks = true };
             var secondChangeToken = new MockChangeToken();
-            var thirdChangeToken = new MockChangeToken { ActiveChangeCallbacks = true };
+            var thirdChangeToken = new MockChangeToken { ActiveChangeCallbacks = false };
             var provider = new CompositeFileProvider(
                 new MockFileProvider(
                     new KeyValuePair<string, IChangeToken>("pattern", firstChangeToken),

--- a/test/Microsoft.AspNet.FileProviders.Embedded.Tests/EmbeddedFileProviderTests.cs
+++ b/test/Microsoft.AspNet.FileProviders.Embedded.Tests/EmbeddedFileProviderTests.cs
@@ -223,7 +223,6 @@ namespace Microsoft.AspNet.FileProviders.Embedded.Tests
             Assert.NotNull(token);
             Assert.False(token.ActiveChangeCallbacks);
             Assert.False(token.HasChanged);
-            Assert.Throws<NotSupportedException>(() => token.RegisterChangeCallback(_ => { }, new object()));
         }
     }
 }


### PR DESCRIPTION
This PR fixes #154.
I have added an EmptyDisposable as singleton (to avoid unnecessary memory allocation).
I have updated the composite file provider to not check the ActiveChangeCallbacks and always pass the callback action and state.