### PR TITLE
Disable mono watcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ os:
   - linux
   - osx
 osx_image: xcode7.1
+env:
+  - MONO_MANAGED_WATCHER=false
 script:
   - ./build.sh verify


### PR DESCRIPTION
This fixes Travis which currently fails with the message `System.IO.IOException : kqueue() FileSystemWatcher has reached the maximum nunmber of files to watch.` (https://travis-ci.org/aspnet/FileSystem/jobs/112436019)