### PR TITLE
Add root to embedded resource

### DIFF
--- a/test/Microsoft.Extensions.FileProviders.Embedded.Tests/EmbeddedFileProviderTests.cs
+++ b/test/Microsoft.Extensions.FileProviders.Embedded.Tests/EmbeddedFileProviderTests.cs
@@ -13,12 +13,42 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
     public class EmbeddedFileProviderTests
     {
         private static readonly string Namespace = typeof(EmbeddedFileProviderTests).Namespace;
+        private static readonly string Root = "/";
+
+        [Fact]
+        public void Constructor_ThrowsFormatException_IfRootContainsInvalidPathCharacters()
+        {
+            foreach (var character in Path.GetInvalidPathChars())
+            {
+                Assert.Throws<FormatException>(() =>
+                {
+                    new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace, character.ToString());
+                });
+            }
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("/")]
+        [InlineData("\\")]
+        public void GetFileInfo_ReturnsNotFoundFileInfo_IfFileDoesNotExist_RegardlessOfRoot(string root)
+        {
+            // Arrange
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace, root);
+
+            // Act
+            var fileInfo = provider.GetFileInfo("DoesNotExist.Txt");
+
+            // Assert
+            Assert.NotNull(fileInfo);
+            Assert.False(fileInfo.Exists);
+        }
 
         [Fact]
         public void GetFileInfo_ReturnsNotFoundFileInfo_IfFileDoesNotExist()
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace, Root);
 
             // Act
             var fileInfo = provider.GetFileInfo("DoesNotExist.Txt");
@@ -34,7 +64,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_ReturnsFilesAtRoot(string filePath)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace, Root);
             var expectedFileLength = 8;
 
             // Act
@@ -54,7 +84,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_ReturnsNotFoundFileInfo_IfFileDoesNotExistUnderSpecifiedNamespace()
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".SubNamespace");
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".SubNamespace", Root);
           
             // Act
             var fileInfo = provider.GetFileInfo("File.txt");
@@ -68,10 +98,24 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_ReturnsNotFoundIfPathStartsWithBackSlash()
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace, Root);
           
             // Act
             var fileInfo = provider.GetFileInfo("\\File.txt");
+
+            // Assert
+            Assert.NotNull(fileInfo);
+            Assert.False(fileInfo.Exists);
+        }
+
+        [Fact]
+        public void GetFileInfo_ReturnsNotFoundIfRootStartsWithBackSlash()
+        {
+            // Arrange
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace, "\\");
+
+            // Act
+            var fileInfo = provider.GetFileInfo("File.txt");
 
             // Assert
             Assert.NotNull(fileInfo);
@@ -101,10 +145,52 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_LocatesFilesUnderSpecifiedNamespace(string path)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".Resources");
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".Resources", Root);
 
             // Act
             var fileInfo = provider.GetFileInfo(path);
+
+            // Assert
+            Assert.NotNull(fileInfo);
+            Assert.True(fileInfo.Exists);
+            Assert.NotEqual(default(DateTimeOffset), fileInfo.LastModified);
+            Assert.True(fileInfo.Length > 0);
+            Assert.False(fileInfo.IsDirectory);
+            Assert.Null(fileInfo.PhysicalPath);
+            Assert.Equal("File3.txt", fileInfo.Name);
+        }
+
+        public static TheoryData GetFileInfo_LocatesFilesUnderSpecifiedRootData
+        {
+            get
+            {
+                var theoryData = new TheoryData<string>
+                {
+                    "/Resources/ResourcesInSubdirectory",
+                    "/Resources/ResourcesInSubdirectory/",
+                    "Resources/ResourcesInSubdirectory/",
+                    "Resources/ResourcesInSubdirectory"
+                };
+
+                if (TestPlatformHelper.IsWindows)
+                {
+                    theoryData.Add("/Resources/ResourcesInSubdirectory\\");
+                    theoryData.Add("Resources/ResourcesInSubdirectory\\");
+                }
+
+                return theoryData;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFileInfo_LocatesFilesUnderSpecifiedRootData))]
+        public void GetFileInfo_LocatesFilesUnderSpecifiedRoot(string root)
+        {
+            // Arrange
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace, root);
+
+            // Act
+            var fileInfo = provider.GetFileInfo("File3.txt");
 
             // Assert
             Assert.NotNull(fileInfo);
@@ -139,7 +225,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_LocatesFilesUnderSubDirectories(string path)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace, Root);
 
             // Act
             var fileInfo = provider.GetFileInfo(path);
@@ -160,7 +246,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetDirectoryContents_ReturnsAllFilesInFileSystem(string path)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".Resources");
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".Resources", Root);
 
             // Act
             var files = provider.GetDirectoryContents(path);
@@ -180,7 +266,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetDirectoryContents_ReturnsEmptySequence_IfResourcesDoNotExistUnderNamespace()
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, "Unknown.Namespace");
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, "Unknown.Namespace", Root);
 
             // Act
             var files = provider.GetDirectoryContents(string.Empty);
@@ -197,7 +283,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetDirectoryContents_ReturnsNotFoundDirectoryContents_IfHierarchicalPathIsSpecified(string path)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace, Root);
 
             // Act
             var files = provider.GetDirectoryContents(path);
@@ -212,7 +298,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void Watch_ReturnsNoOpTrigger()
         {
             // Arange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace, Root);
 
             // Act
             var token = provider.Watch("Resources/File.txt");

--- a/test/Microsoft.Extensions.FileProviders.Embedded.Tests/project.json
+++ b/test/Microsoft.Extensions.FileProviders.Embedded.Tests/project.json
@@ -20,7 +20,8 @@
     },
     "net451": {
       "frameworkAssemblies": {
-        "System.Runtime": ""
+        "System.Runtime": "",
+        "System.Threading.Tasks": ""
       },
       "dependencies": {
         "xunit.runner.console": "2.1.0"


### PR DESCRIPTION
This allows a request to provide a relative path to the resource.
While the existing `assembly` parameter can acheive the same outcome, allowing the use of path-references mirrors the location of the resource in the project (as stored in the filesystem).

Example:

`directory structure`
- styles
  - css
    - site.css

`project.json`
```json
{
    "resource": [ "styles/**" ]
}
```

```csharp
// Existing behavior
var provider new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, GetType().Namespace + ".styles.css");
provider.GetFileInfo("site.css");

// Proposed behavior
var provider new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, GetType().Namespace, "/styles/css");
provider.GetFileInfo("site.css");
```