### PR TITLE
expose NoopChangeToken, NotFoundDirectoryContents, NotFoundFileInfo as public

### DIFF
--- a/src/Microsoft.Extensions.FileProviders.Abstractions/NotFoundDirectoryContents.cs
+++ b/src/Microsoft.Extensions.FileProviders.Abstractions/NotFoundDirectoryContents.cs
@@ -7,7 +7,10 @@ using System.Linq;
 
 namespace Microsoft.Extensions.FileProviders
 {
-    internal class NotFoundDirectoryContents : IDirectoryContents
+    /// <summary>
+    /// Represents a non-existing directory
+    /// </summary>
+    public class NotFoundDirectoryContents : IDirectoryContents
     {
         public bool Exists => false;
 

--- a/src/Microsoft.Extensions.FileProviders.Abstractions/NotFoundFileInfo.cs
+++ b/src/Microsoft.Extensions.FileProviders.Abstractions/NotFoundFileInfo.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.FileProviders
     /// <summary>
     /// Represents a non-existing file.
     /// </summary>
-    internal class NotFoundFileInfo : IFileInfo
+    public class NotFoundFileInfo : IFileInfo
     {
         public NotFoundFileInfo(string name)
         {

--- a/src/Microsoft.Extensions.FileProviders.Abstractions/NullChangeToken.cs
+++ b/src/Microsoft.Extensions.FileProviders.Abstractions/NullChangeToken.cs
@@ -6,11 +6,14 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.FileProviders
 {
-    internal class NoopChangeToken : IChangeToken
+    /// <summary>
+    /// An empty change token that doesn't raise any change callbacks
+    /// </summary>
+    public class NullChangeToken : IChangeToken
     {
-        public static NoopChangeToken Singleton { get; } = new NoopChangeToken();
+        public static NullChangeToken Singleton { get; } = new NullChangeToken();
 
-        private NoopChangeToken()
+        private NullChangeToken()
         {
         }
 

--- a/src/Microsoft.Extensions.FileProviders.Abstractions/NullFileProvider.cs
+++ b/src/Microsoft.Extensions.FileProviders.Abstractions/NullFileProvider.cs
@@ -29,6 +29,6 @@ namespace Microsoft.Extensions.FileProviders
         /// </summary>
         /// <param name="filter">Filter string used to determine what files or folders to monitor. This parameter is ignored.</param>
         /// <returns>A <see cref="IChangeToken"/> that does not register callbacks.</returns>
-        public IChangeToken Watch(string filter) => NoopChangeToken.Singleton;
+        public IChangeToken Watch(string filter) => NullChangeToken.Singleton;
     }
 }

--- a/src/Microsoft.Extensions.FileProviders.Composite/CompositeFileProvider.cs
+++ b/src/Microsoft.Extensions.FileProviders.Composite/CompositeFileProvider.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Extensions.FileProviders
             // There is no change token with active change callbacks
             if (changeTokens.Count == 0)
             {
-                return NoopChangeToken.Singleton;
+                return NullChangeToken.Singleton;
             }
             var CompositeFileChangeToken = new CompositeFileChangeToken(changeTokens);
             return CompositeFileChangeToken;

--- a/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedFileProvider.cs
+++ b/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedFileProvider.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Extensions.FileProviders
 
         public IChangeToken Watch(string pattern)
         {
-            return NoopChangeToken.Singleton;
+            return NullChangeToken.Singleton;
         }
 
         private static bool HasInvalidPathChars(string path)

--- a/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileProvider.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileProvider.cs
@@ -240,12 +240,12 @@ namespace Microsoft.Extensions.FileProviders
         {
             if (filter == null)
             {
-                return NoopChangeToken.Singleton;
+                return NullChangeToken.Singleton;
             }
 
             if (PathNavigatesAboveRoot(filter))
             {
-                return NoopChangeToken.Singleton;
+                return NullChangeToken.Singleton;
             }
 
             // Relative paths starting with a leading slash okay
@@ -257,7 +257,7 @@ namespace Microsoft.Extensions.FileProviders
             // Absolute paths not permitted.
             if (Path.IsPathRooted(filter))
             {
-                return NoopChangeToken.Singleton;
+                return NullChangeToken.Singleton;
             }
 
             return _filesWatcher.CreateFileChangeToken(filter);

--- a/test/Microsoft.Extensions.FileProviders.Composite.Tests/MockFileProvider.cs
+++ b/test/Microsoft.Extensions.FileProviders.Composite.Tests/MockFileProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Extensions.FileProviders.Composite
             {
                 return _changeTokens[filter];
             }
-            return NoopChangeToken.Singleton;
+            return NullChangeToken.Singleton;
         }
     }
 }

--- a/test/Microsoft.Extensions.FileProviders.Physical.Tests/PhysicalFileProviderTests.cs
+++ b/test/Microsoft.Extensions.FileProviders.Physical.Tests/PhysicalFileProviderTests.cs
@@ -659,7 +659,7 @@ namespace Microsoft.Extensions.FileProviders
                 {
                     var token = provider.Watch(null);
 
-                    Assert.Same(NoopChangeToken.Singleton, token);
+                    Assert.Same(NullChangeToken.Singleton, token);
                 }
             }
         }
@@ -673,7 +673,7 @@ namespace Microsoft.Extensions.FileProviders
                 {
                     var token = provider.Watch(Path.Combine("a", "..", "..", root.DirectoryInfo.Name, "b"));
 
-                    Assert.Same(NoopChangeToken.Singleton, token);
+                    Assert.Same(NullChangeToken.Singleton, token);
                 }
             }
         }
@@ -722,7 +722,7 @@ namespace Microsoft.Extensions.FileProviders
                     var path = Path.Combine(root.RootPath, Guid.NewGuid().ToString());
                     var token = provider.Watch(path);
 
-                    Assert.Same(NoopChangeToken.Singleton, token);
+                    Assert.Same(NullChangeToken.Singleton, token);
                 }
             }
         }


### PR DESCRIPTION
changes as per the discussion on issue https://github.com/aspnet/FileSystem/issues/145

unit tests passing (executed via dotnet test)