### PR TITLE
Set embedded files provider namespace to assembly name by default

### DIFF
--- a/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedFileProvider.cs
+++ b/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedFileProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.FileProviders
         /// </summary>
         /// <param name="assembly"></param>
         public EmbeddedFileProvider(Assembly assembly)
-            : this(assembly, string.Empty)
+            : this(assembly, assembly?.GetName()?.Name)
         {
         }
 

--- a/test/Microsoft.Extensions.FileProviders.Embedded.Tests/EmbeddedFileProviderTests.cs
+++ b/test/Microsoft.Extensions.FileProviders.Embedded.Tests/EmbeddedFileProviderTests.cs
@@ -15,10 +15,16 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         private static readonly string Namespace = typeof(EmbeddedFileProviderTests).Namespace;
 
         [Fact]
+        public void ConstructorWithNullAssemblyThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new EmbeddedFileProvider(null));
+        }
+
+        [Fact]
         public void GetFileInfo_ReturnsNotFoundFileInfo_IfFileDoesNotExist()
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
 
             // Act
             var fileInfo = provider.GetFileInfo("DoesNotExist.Txt");
@@ -34,7 +40,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_ReturnsFilesAtRoot(string filePath)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
             var expectedFileLength = 8;
 
             // Act
@@ -55,7 +61,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         {
             // Arrange
             var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".SubNamespace");
-          
+
             // Act
             var fileInfo = provider.GetFileInfo("File.txt");
 
@@ -68,8 +74,8 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_ReturnsNotFoundIfPathStartsWithBackSlash()
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
-          
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
+
             // Act
             var fileInfo = provider.GetFileInfo("\\File.txt");
 
@@ -139,7 +145,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_LocatesFilesUnderSubDirectories(string path)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
 
             // Act
             var fileInfo = provider.GetFileInfo(path);
@@ -197,7 +203,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetDirectoryContents_ReturnsNotFoundDirectoryContents_IfHierarchicalPathIsSpecified(string path)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
 
             // Act
             var files = provider.GetDirectoryContents(path);
@@ -212,7 +218,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void Watch_ReturnsNoOpTrigger()
         {
             // Arange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace);
+            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
 
             // Act
             var token = provider.Watch("Resources/File.txt");


### PR DESCRIPTION
Fixes: https://github.com/aspnet/FileSystem/issues/190
@pranavkm @BrennanConroy 