### PR TITLE
Support of non-flat tree in the Embedded Resource File Provider.

### DIFF
--- a/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedFileProvider.cs
+++ b/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedFileProvider.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Extensions.FileProviders
         private readonly Assembly _assembly;
         private readonly string _baseNamespace;
         private readonly DateTimeOffset _lastModified;
+        private readonly Dictionary<string, IFileInfo> _allEntries;         // Values may be 'null' if information must be dynamically calculated
+        private readonly Dictionary<string, List<IFileInfo>> _directories;  // Values are directory children
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EmbeddedFileProvider" /> class using the specified
@@ -41,6 +43,29 @@ namespace Microsoft.Extensions.FileProviders
         /// <param name="assembly">The assembly that contains the embedded resources.</param>
         /// <param name="baseNamespace">The base namespace that contains the embedded resources.</param>
         public EmbeddedFileProvider(Assembly assembly, string baseNamespace)
+            : this(assembly, baseNamespace, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmbeddedFileProvider" /> class using the specified
+        /// assembly and base namespace.
+        /// </summary>
+        /// <param name="assembly">The assembly that contains the embedded resources.</param>
+        /// <param name="resourcePathSplitter">Function that takes the resource path and boolean (False for a file, True for a directory), and returns a <see cref="SplitResourcePath" /> from it.</param>
+        public EmbeddedFileProvider(Assembly assembly, Func<string, bool, SplitResourcePath> resourcePathSplitter)
+            : this(assembly, assembly?.GetName()?.Name, resourcePathSplitter)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmbeddedFileProvider" /> class using the specified
+        /// assembly and base namespace.
+        /// </summary>
+        /// <param name="assembly">The assembly that contains the embedded resources.</param>
+        /// <param name="baseNamespace">The base namespace that contains the embedded resources.</param>
+        /// <param name="resourcePathSplitter">Function that takes the resource path and boolean (False for a file, True for a directory), and returns a <see cref="SplitResourcePath" /> from it.</param>
+        public EmbeddedFileProvider(Assembly assembly, string baseNamespace, Func<string, bool, SplitResourcePath> resourcePathSplitter)
         {
             if (assembly == null)
             {
@@ -53,7 +78,7 @@ namespace Microsoft.Extensions.FileProviders
             _lastModified = DateTimeOffset.UtcNow;
 
 
-// need to keep netstandard1.0 until ASP.NET Core 2.0 because it is a breaking change if we remove it
+            // need to keep netstandard1.0 until ASP.NET Core 2.0 because it is a breaking change if we remove it
 #if NETSTANDARD1_5 || NET451
             if (!string.IsNullOrEmpty(_assembly.Location))
             {
@@ -69,6 +94,13 @@ namespace Microsoft.Extensions.FileProviders
                 }
             }
 #endif
+
+            _allEntries = new Dictionary<string, IFileInfo>();
+            _directories = new Dictionary<string, List<IFileInfo>>();
+
+            LoadRoot();
+            LoadFiles(resourcePathSplitter);
+            LoadDirectories(resourcePathSplitter);
         }
 
         /// <summary>
@@ -83,40 +115,31 @@ namespace Microsoft.Extensions.FileProviders
                 return new NotFoundFileInfo(subpath);
             }
 
-            var builder = new StringBuilder(_baseNamespace.Length + subpath.Length);
-            builder.Append(_baseNamespace);
-
-            // Relative paths starting with a leading slash okay
-            if (subpath.StartsWith("/", StringComparison.Ordinal))
-            {
-                builder.Append(subpath, 1, subpath.Length - 1);
-            }
-            else
-            {
-                builder.Append(subpath);
-            }
-
-            for (var i = _baseNamespace.Length; i < builder.Length; i++)
-            {
-                if (builder[i] == '/' || builder[i] == '\\')
-                {
-                    builder[i] = '.';
-                }
-            }
-
-            var resourcePath = builder.ToString();
+            var resourcePath = PrepareSubpath(subpath);
             if (HasInvalidPathChars(resourcePath))
             {
                 return new NotFoundFileInfo(resourcePath);
             }
 
-            var name = Path.GetFileName(subpath);
-            if (_assembly.GetManifestResourceInfo(resourcePath) == null)
+            IFileInfo fileInfo = null;
+            if (_allEntries.TryGetValue(resourcePath, out fileInfo) && fileInfo == null)
             {
+                // If there is no 'splitter', the file name is calculated dynamically because a same
+                // resource file "foo.bar" will have different names, depending on the sub-path:
+                // GetFileInfo("/foo/bar") --> "bar"
+                // GetFileInfo("/foo.bar") --> "foo.bar"
+                var fullResourcePath = _baseNamespace + resourcePath;
+                var name = Path.GetFileName(subpath);
+                fileInfo = new EmbeddedResourceFileInfo(_assembly, fullResourcePath, name, _lastModified);
+            }
+
+            if (fileInfo == null)
+            {
+                var name = Path.GetFileName(subpath);
                 return new NotFoundFileInfo(name);
             }
 
-            return new EmbeddedResourceFileInfo(_assembly, resourcePath, name, _lastModified);
+            return fileInfo;
         }
 
         /// <summary>
@@ -133,33 +156,16 @@ namespace Microsoft.Extensions.FileProviders
                 return new NotFoundDirectoryContents();
             }
 
-            // Relative paths starting with a leading slash okay
-            if (subpath.StartsWith("/", StringComparison.Ordinal))
-            {
-                subpath = subpath.Substring(1);
-            }
-
-            // Non-hierarchal.
-            if (!subpath.Equals(string.Empty))
+            var resourcePath = PrepareSubpath(subpath);
+            if (HasInvalidPathChars(resourcePath))
             {
                 return new NotFoundDirectoryContents();
             }
 
-            var entries = new List<IFileInfo>();
-
-            // TODO: The list of resources in an assembly isn't going to change. Consider caching.
-            var resources = _assembly.GetManifestResourceNames();
-            for (var i = 0; i < resources.Length; i++)
+            List<IFileInfo> entries;
+            if (!_directories.TryGetValue(resourcePath, out entries))
             {
-                var resourceName = resources[i];
-                if (resourceName.StartsWith(_baseNamespace))
-                {
-                    entries.Add(new EmbeddedResourceFileInfo(
-                        _assembly,
-                        resourceName,
-                        resourceName.Substring(_baseNamespace.Length),
-                        _lastModified));
-                }
+                return new NotFoundDirectoryContents();
             }
 
             return new EnumerableDirectoryContents(entries);
@@ -173,6 +179,150 @@ namespace Microsoft.Extensions.FileProviders
         private static bool HasInvalidPathChars(string path)
         {
             return path.IndexOfAny(_invalidFileNameChars) != -1;
+        }
+
+        private static string PrepareSubpath(string subpath)
+        {
+            var builder = new StringBuilder(subpath.Length);
+
+            // Relative paths starting with a leading slash okay
+            if (subpath.StartsWith("/", StringComparison.Ordinal))
+            {
+                builder.Append(subpath, 1, subpath.Length - 1);
+            }
+            else
+            {
+                builder.Append(subpath);
+            }
+
+            for (var i = 0; i < builder.Length; i++)
+            {
+                if (builder[i] == '/' || builder[i] == '\\')
+                {
+                    builder[i] = '.';
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private void LoadRoot()
+        {
+            // The root directory must never fail, so load the minimum...
+            _directories.Add(string.Empty, new List<IFileInfo>());
+            _allEntries.Add(string.Empty, new EmbeddedResourceDirectoryInfo(string.Empty, _lastModified));
+        }
+
+        private void LoadFiles(Func<string, bool, SplitResourcePath> resourcePathSplitter)
+        {
+            var resources = _assembly.GetManifestResourceNames();
+            if (resources != null)
+            {
+                for (int i = 0; i < resources.Length; i++)
+                {
+                    if (resources[i].StartsWith(_baseNamespace, StringComparison.Ordinal))
+                    {
+                        var relativeResourceName = resources[i].Substring(_baseNamespace.Length);
+                        string fileName;
+                        string parentPath;
+                        string fullPath;
+                        bool dynamicFileInfo;
+
+                        if (resourcePathSplitter != null)
+                        {
+                            var split = resourcePathSplitter(relativeResourceName, false);
+                            if (string.IsNullOrEmpty(split.Name))
+                            {
+                                throw new ArgumentNullException(nameof(split.Name));
+                            }
+                            fileName = split.Name;
+
+                            dynamicFileInfo = false;
+
+                            if (!string.IsNullOrEmpty(split.ParentDirectory))
+                            {
+                                parentPath = split.ParentDirectory;
+                                fullPath = split.ParentDirectory + '.' + split.Name;
+                            }
+                            else
+                            {
+                                parentPath = string.Empty;
+                                fullPath = split.Name;
+                            }
+                        }
+                        else
+                        {
+                            fileName = relativeResourceName;
+                            parentPath = string.Empty;
+                            fullPath = relativeResourceName;
+                            dynamicFileInfo = true;
+                        }
+
+                        var fileInfo = new EmbeddedResourceFileInfo(
+                            _assembly,
+                            resources[i],
+                            fileName,
+                            _lastModified);
+
+                        AddEntry(fullPath, (!dynamicFileInfo) ? fileInfo : null);
+                        AddDirectoryChild(parentPath, fileInfo);
+                    }
+                }
+            }
+        }
+
+        private void AddEntry(string entryPath, IFileInfo entry)
+        {
+            IFileInfo existing;
+            if (!_allEntries.TryGetValue(entryPath, out existing))
+            {
+                _allEntries.Add(entryPath, entry);
+            }
+        }
+
+        private void AddDirectoryChild(string directory, IFileInfo child)
+        {
+            List<IFileInfo> children;
+            if (!_directories.TryGetValue(directory, out children))
+            {
+                children = new List<IFileInfo>();
+                _directories.Add(directory, children);
+            }
+
+            if (!children.Exists(e => e.Name == child.Name))
+            {
+                children.Add(child);
+            }
+        }
+
+        private void LoadDirectories(Func<string, bool, SplitResourcePath> resourcePathSplitter)
+        {
+            if (resourcePathSplitter != null)
+            {
+                var toAnalyze = _directories.Keys.ToArray();
+                for (int i = 0; i < toAnalyze.Length; i++)
+                {
+                    string path = toAnalyze[i];
+                    SplitResourcePath split;
+
+                    do
+                    {
+                        split = resourcePathSplitter(path, true);
+
+                        if (!string.IsNullOrEmpty(split.Name))
+                        {
+                            var parent = split.ParentDirectory ?? string.Empty;
+                            var fileInfo = new EmbeddedResourceDirectoryInfo(split.Name, _lastModified);
+
+                            AddEntry(path, fileInfo);
+                            AddDirectoryChild(parent, fileInfo);
+                        }
+
+                        path = split.ParentDirectory;
+                    }
+                    while (!string.IsNullOrEmpty(path));
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedResourceDirectoryInfo.cs
+++ b/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedResourceDirectoryInfo.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Extensions.FileProviders.Embedded
+{
+    public class EmbeddedResourceDirectoryInfo : IFileInfo
+    {
+        public EmbeddedResourceDirectoryInfo(string name, DateTimeOffset lastModified)
+        {
+            Name = name;
+            LastModified = lastModified;
+        }
+
+        public bool Exists => true;
+
+        public long Length => -1;
+
+        public string PhysicalPath => null;
+
+        public string Name { get; }
+
+        public DateTimeOffset LastModified { get; }
+
+        public bool IsDirectory => true;
+
+        public Stream CreateReadStream()
+        {
+            throw new InvalidOperationException("Cannot create a stream for a directory.");
+        }
+    }
+}

--- a/src/Microsoft.Extensions.FileProviders.Embedded/SplitResourcePath.cs
+++ b/src/Microsoft.Extensions.FileProviders.Embedded/SplitResourcePath.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.FileProviders
+{
+    public struct SplitResourcePath
+    {
+        public string ParentDirectory { get; set; }
+
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
See #206.
- Added a parameter `isDirectory` in the split function to be able to have specific processing depending on the path is a file or a directory.
- Keeped the current behavior when there is no 'splitter'. But of course in this case it keeps the difference between `GetFileInfo()` that supports more or less subpaths while `GetDirectoryContents()` does not support them.

Pending:
- The `CreateFromFileExtensions()` helper method. I wait your validation on the first PR.
