### PR TITLE
Reduce allocation in PhysicalFileProvider when used in StaticFiles

### DIFF
--- a/src/Microsoft.Extensions.FileProviders.Physical/FileSystemInfoHelper.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/FileSystemInfoHelper.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Extensions.FileProviders
                 return true;
             }
             else if (fileSystemInfo.Exists &&
-                (fileSystemInfo.Attributes.HasFlag(FileAttributes.Hidden) ||
-                fileSystemInfo.Attributes.HasFlag(FileAttributes.System)))
+                ((fileSystemInfo.Attributes & FileAttributes.Hidden) != 0 ||
+                 (fileSystemInfo.Attributes & FileAttributes.System) != 0))
             {
                 return true;
             }

--- a/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileInfo.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileInfo.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Extensions.FileProviders.Physical
 {
     public class PhysicalFileInfo : IFileInfo
     {
+        private const int MaxBufferSize = 1024 * 64;
+        // Note: Buffer size must be greater than zero, even if the file size is zero
+        // otherwise FileStream constructor will throw
+        private const int MinBufferSize = 1;
+
         private readonly FileInfo _info;
 
         public PhysicalFileInfo(FileInfo info)
@@ -29,8 +34,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
         public Stream CreateReadStream()
         {
-            // Note: Buffer size must be greater than zero, even if the file size is zero.
-            var bufferSize = (int)Math.Min(1024 * 64, Math.Max(1, Length));
+            var bufferSize = (int)Math.Min(MaxBufferSize, Math.Max(MinBufferSize, Length));
             return new FileStream(
                 PhysicalPath,
                 FileMode.Open,

--- a/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileInfo.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileInfo.cs
@@ -30,12 +30,13 @@ namespace Microsoft.Extensions.FileProviders.Physical
         public Stream CreateReadStream()
         {
             // Note: Buffer size must be greater than zero, even if the file size is zero.
+            var bufferSize = (int)Math.Min(1024 * 64, Math.Max(1, Length));
             return new FileStream(
                 PhysicalPath,
                 FileMode.Open,
                 FileAccess.Read,
                 FileShare.ReadWrite,
-                Math.Min((int)Length, 1024 * 64),
+                bufferSize,
                 FileOptions.Asynchronous | FileOptions.SequentialScan);
         }
     }

--- a/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileInfo.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileInfo.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
                 FileMode.Open,
                 FileAccess.Read,
                 FileShare.ReadWrite,
-                1024 * 64,
+                Math.Min((int)Length, 1024 * 64),
                 FileOptions.Asynchronous | FileOptions.SequentialScan);
         }
     }

--- a/test/Microsoft.Extensions.FileProviders.Physical.Tests/PhysicalFileProviderTests.cs
+++ b/test/Microsoft.Extensions.FileProviders.Physical.Tests/PhysicalFileProviderTests.cs
@@ -114,6 +114,23 @@ namespace Microsoft.Extensions.FileProviders
             }
         }
 
+        [Fact]
+        public void CreateReadStreamSuccedsOnEmptyFile()
+        {
+            using (var root = new DisposableFileSystem())
+            {
+                using (var provider = new PhysicalFileProvider(root.RootPath))
+                {
+                    var fileName = Guid.NewGuid().ToString();
+                    var filePath = Path.Combine(root.RootPath, fileName);
+                    using (File.Create(filePath)) { }
+                    var info = provider.GetFileInfo(fileName);
+                    var stream = info.CreateReadStream();
+                    Assert.NotNull(stream);
+                }
+            }
+        }
+
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux, SkipReason = "Hidden and system files only make sense on Windows.")]
         [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Hidden and system files only make sense on Windows.")]

--- a/test/Microsoft.Extensions.FileProviders.Physical.Tests/PhysicalFileProviderTests.cs
+++ b/test/Microsoft.Extensions.FileProviders.Physical.Tests/PhysicalFileProviderTests.cs
@@ -123,10 +123,12 @@ namespace Microsoft.Extensions.FileProviders
                 {
                     var fileName = Guid.NewGuid().ToString();
                     var filePath = Path.Combine(root.RootPath, fileName);
-                    using (File.Create(filePath)) { }
+                    File.WriteAllBytes(filePath, new byte[0]);
                     var info = provider.GetFileInfo(fileName);
-                    var stream = info.CreateReadStream();
-                    Assert.NotNull(stream);
+                    using (var stream = info.CreateReadStream())
+                    {
+                        Assert.NotNull(stream);
+                    }
                 }
             }
         }


### PR DESCRIPTION
By default we pass 64k buffer size but it causes significant overhead for small sized files.
## Before:
Using 200byte file
![http://i.imgur.com/DjMpeyl.png](http://i.imgur.com/DjMpeyl.png)

## After:
![http://i.imgur.com/7EwGxZY.png](http://i.imgur.com/7EwGxZY.png)

@Tratcher  
@davidfowl ` // Note: Buffer size must be greater than zero, even if the file size is zero.` why?