### PR TITLE
Add missing xml docs for all file provider implementations

### DIFF
--- a/src/Microsoft.Extensions.FileProviders.Composite/CompositeDirectoryContents.cs
+++ b/src/Microsoft.Extensions.FileProviders.Composite/CompositeDirectoryContents.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Extensions.FileProviders.Composite
         }
 
         /// <summary>
-        /// Creates an enumerator for all files in all providers given. Does not duplicate items, even if multiple providers for the same file exist.
+        /// Creates an enumerator for all files in all providers given.
+        /// Ensures each item in the collection is distinct.
         /// </summary>
         /// <returns>An enumerator over all files in all given providers</returns>
         public IEnumerator<IFileInfo> GetEnumerator()

--- a/src/Microsoft.Extensions.FileProviders.Composite/CompositeDirectoryContents.cs
+++ b/src/Microsoft.Extensions.FileProviders.Composite/CompositeDirectoryContents.cs
@@ -73,6 +73,10 @@ namespace Microsoft.Extensions.FileProviders.Composite
             }
         }
 
+        /// <summary>
+        /// Creates an enumerator for all files in all providers given. Does not duplicate items, even if multiple providers for the same file exist.
+        /// </summary>
+        /// <returns>An enumerator over all files in all given providers</returns>
         public IEnumerator<IFileInfo> GetEnumerator()
         {
             EnsureFilesAreInitialized();
@@ -85,6 +89,9 @@ namespace Microsoft.Extensions.FileProviders.Composite
             return _files.GetEnumerator();
         }
 
+        /// <summary>
+        /// True if any given providers exists
+        /// </summary>
         public bool Exists
         {
             get

--- a/src/Microsoft.Extensions.FileProviders.Composite/CompositeFileProvider.cs
+++ b/src/Microsoft.Extensions.FileProviders.Composite/CompositeFileProvider.cs
@@ -10,25 +10,25 @@ using Microsoft.Extensions.Primitives;
 namespace Microsoft.Extensions.FileProviders
 {
     /// <summary>
-    /// Looks up files using a list of <see cref="IFileProvider"/>.
+    /// Looks up files using a collection of <see cref="IFileProvider"/>.
     /// </summary>
     public class CompositeFileProvider : IFileProvider
     {
         private readonly IFileProvider[] _fileProviders;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CompositeFileProvider" /> class using a list of file provider.
+        /// Initializes a new instance of the <see cref="CompositeFileProvider" /> class using a collection of file provider.
         /// </summary>
-        /// <param name="fileProviders"></param>
+        /// <param name="fileProviders">The collection of <see cref="IFileProvider" /></param>
         public CompositeFileProvider(params IFileProvider[] fileProviders)
         {
             _fileProviders = fileProviders ?? new IFileProvider[0];
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CompositeFileProvider" /> class using a list of file provider.
+        /// Initializes a new instance of the <see cref="CompositeFileProvider" /> class using a collection of file provider.
         /// </summary>
-        /// <param name="fileProviders"></param>
+        /// <param name="fileProviders">The collection of <see cref="IFileProvider" /></param>
         public CompositeFileProvider(IEnumerable<IFileProvider> fileProviders)
         {
             if (fileProviders == null)

--- a/src/Microsoft.Extensions.FileProviders.Composite/project.json
+++ b/src/Microsoft.Extensions.FileProviders.Composite/project.json
@@ -3,9 +3,6 @@
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",
-    "nowarn": [
-      "CS1591"
-    ],
     "xmlDoc": true
   },
   "description": "Composite file and directory providers for Microsoft.Extensions.FileProviders.",

--- a/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedFileProvider.cs
+++ b/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedFileProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.FileProviders
         /// Initializes a new instance of the <see cref="EmbeddedFileProvider" /> class using the specified
         /// assembly and empty base namespace.
         /// </summary>
-        /// <param name="assembly"></param>
+        /// <param name="assembly">The assembly that contains the embedded resources.</param>
         public EmbeddedFileProvider(Assembly assembly)
             : this(assembly, assembly?.GetName()?.Name)
         {
@@ -176,7 +176,7 @@ namespace Microsoft.Extensions.FileProviders
         /// <summary>
         /// Embedded files do not change.
         /// </summary>
-        /// <param name="pattern"></param>
+        /// <param name="pattern">This parameter is ignored</param>
         /// <returns>A <see cref="NullChangeToken" /></returns>
         public IChangeToken Watch(string pattern)
         {

--- a/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedFileProvider.cs
+++ b/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedFileProvider.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.FileProviders
     {
         private static readonly char[] _invalidFileNameChars = Path.GetInvalidFileNameChars()
             .Where(c => c != '/' && c != '\\').ToArray();
+
         private readonly Assembly _assembly;
         private readonly string _baseNamespace;
         private readonly DateTimeOffset _lastModified;
@@ -75,7 +76,10 @@ namespace Microsoft.Extensions.FileProviders
         /// Locates a file at the given path.
         /// </summary>
         /// <param name="subpath">The path that identifies the file. </param>
-        /// <returns>The file information. Caller must check Exists property.</returns>
+        /// <returns>
+        /// The file information. Caller must check Exists property. A <see cref="NotFoundFileInfo" /> if the file could
+        /// not be found.
+        /// </returns>
         public IFileInfo GetFileInfo(string subpath)
         {
             if (string.IsNullOrEmpty(subpath))
@@ -121,10 +125,14 @@ namespace Microsoft.Extensions.FileProviders
 
         /// <summary>
         /// Enumerate a directory at the given path, if any.
-        /// This file provider uses a flat directory structure. Everything under the base namespace is considered to be one directory.
+        /// This file provider uses a flat directory structure. Everything under the base namespace is considered to be one
+        /// directory.
         /// </summary>
         /// <param name="subpath">The path that identifies the directory</param>
-        /// <returns>Contents of the directory. Caller must check Exists property.</returns>
+        /// <returns>
+        /// Contents of the directory. Caller must check Exists property. A <see cref="NotFoundDirectoryContents" /> if no
+        /// resources were found that match <paramref name="subpath" />
+        /// </returns>
         public IDirectoryContents GetDirectoryContents(string subpath)
         {
             // The file name is assumed to be the remainder of the resource name.
@@ -165,6 +173,11 @@ namespace Microsoft.Extensions.FileProviders
             return new EnumerableDirectoryContents(entries);
         }
 
+        /// <summary>
+        /// Embedded files do not change.
+        /// </summary>
+        /// <param name="pattern"></param>
+        /// <returns>A <see cref="NullChangeToken" /></returns>
         public IChangeToken Watch(string pattern)
         {
             return NullChangeToken.Singleton;

--- a/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedResourceFileInfo.cs
+++ b/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedResourceFileInfo.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Extensions.FileProviders.Embedded
         /// <summary>
         /// Initializes a new instance of <see cref="EmbeddedFileProvider"/> for an assembly using <paramref name="resourcePath"/> as the base
         /// </summary>
-        /// <param name="assembly"></param>
-        /// <param name="resourcePath"></param>
+        /// <param name="assembly">The assembly that contains the embedded resource</param>
+        /// <param name="resourcePath">The path to the embedded resource</param>
         /// <param name="name">An arbitrary name for this instance</param>
-        /// <param name="lastModified"></param>
+        /// <param name="lastModified">The <see cref="DateTimeOffset" /> to use for <see cref="LastModified" /></param>
         public EmbeddedResourceFileInfo(
             Assembly assembly,
             string resourcePath,

--- a/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedResourceFileInfo.cs
+++ b/src/Microsoft.Extensions.FileProviders.Embedded/EmbeddedResourceFileInfo.cs
@@ -7,6 +7,9 @@ using System.Reflection;
 
 namespace Microsoft.Extensions.FileProviders.Embedded
 {
+    /// <summary>
+    /// Represents a file embedded in an assembly.
+    /// </summary>
     public class EmbeddedResourceFileInfo : IFileInfo
     {
         private readonly Assembly _assembly;
@@ -14,6 +17,13 @@ namespace Microsoft.Extensions.FileProviders.Embedded
 
         private long? _length;
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="EmbeddedFileProvider"/> for an assembly using <paramref name="resourcePath"/> as the base
+        /// </summary>
+        /// <param name="assembly"></param>
+        /// <param name="resourcePath"></param>
+        /// <param name="name">An arbitrary name for this instance</param>
+        /// <param name="lastModified"></param>
         public EmbeddedResourceFileInfo(
             Assembly assembly,
             string resourcePath,
@@ -26,8 +36,14 @@ namespace Microsoft.Extensions.FileProviders.Embedded
             LastModified = lastModified;
         }
 
+        /// <summary>
+        /// Always true.
+        /// </summary>
         public bool Exists => true;
 
+        /// <summary>
+        /// The length, in bytes, of the embedded resource
+        /// </summary>
         public long Length
         {
             get
@@ -43,15 +59,27 @@ namespace Microsoft.Extensions.FileProviders.Embedded
             }
         }
 
-        // Not directly accessible.
+        /// <summary>
+        /// Always null.
+        /// </summary>
         public string PhysicalPath => null;
 
+        /// <summary>
+        /// The name of embedded file
+        /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// The time, in UTC, when the <see cref="EmbeddedFileProvider"/> was created
+        /// </summary>
         public DateTimeOffset LastModified { get; }
 
+        /// <summary>
+        /// Always false.
+        /// </summary>
         public bool IsDirectory => false;
 
+        /// <inheritdoc />
         public Stream CreateReadStream()
         {
             var stream = _assembly.GetManifestResourceStream(_resourcePath);

--- a/src/Microsoft.Extensions.FileProviders.Embedded/Microsoft.Extensions.FileProviders.Embedded.xproj
+++ b/src/Microsoft.Extensions.FileProviders.Embedded/Microsoft.Extensions.FileProviders.Embedded.xproj
@@ -10,6 +10,9 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <RootNamespace>Microsoft.Extensions.FileProviders</RootNamespace>
+  </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/Microsoft.Extensions.FileProviders.Embedded/project.json
+++ b/src/Microsoft.Extensions.FileProviders.Embedded/project.json
@@ -3,9 +3,6 @@
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",
-    "nowarn": [
-      "CS1591"
-    ],
     "xmlDoc": true
   },
   "description": "File provider for files in embedded resources for Microsoft.Extensions.FileProviders.",

--- a/src/Microsoft.Extensions.FileProviders.Physical/FileSystemInfoHelper.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/FileSystemInfoHelper.cs
@@ -5,7 +5,10 @@ using System.IO;
 
 namespace Microsoft.Extensions.FileProviders
 {
-    public class FileSystemInfoHelper
+    /// <summary>
+    /// Helper functions for working with the filesystem
+    /// </summary>
+    public static class FileSystemInfoHelper
     {
         internal static bool IsHiddenFile(FileSystemInfo fileSystemInfo)
         {

--- a/src/Microsoft.Extensions.FileProviders.Physical/Microsoft.Extensions.FileProviders.Physical.xproj
+++ b/src/Microsoft.Extensions.FileProviders.Physical/Microsoft.Extensions.FileProviders.Physical.xproj
@@ -10,6 +10,9 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <RootNamespace>Microsoft.Extensions.FileProviders</RootNamespace>
+  </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/Microsoft.Extensions.FileProviders.Physical/PhysicalDirectoryInfo.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PhysicalDirectoryInfo.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
     public class PhysicalDirectoryInfo : IFileInfo
     {
         private readonly DirectoryInfo _info;
-        
+
         /// <summary>
         /// Initializes an instance of <see cref="PhysicalDirectoryInfo"/> that wraps an instance of <see cref="System.IO.DirectoryInfo"/>
         /// </summary>
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         public string Name => _info.Name;
 
         /// <summary>
-        /// The time when the directory was last written to. 
+        /// The time when the directory was last written to.
         /// </summary>
         public DateTimeOffset LastModified => _info.LastWriteTimeUtc;
 
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         /// Always throws an exception because read streams are not support on directories.
         /// </summary>
         /// <exception cref="InvalidOperationException">Always thrown</exception>
-        /// <returns></returns>
+        /// <returns>Never returns</returns>
         public Stream CreateReadStream()
         {
             throw new InvalidOperationException("Cannot create a stream for a directory.");

--- a/src/Microsoft.Extensions.FileProviders.Physical/PhysicalDirectoryInfo.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PhysicalDirectoryInfo.cs
@@ -6,27 +6,51 @@ using System.IO;
 
 namespace Microsoft.Extensions.FileProviders.Physical
 {
+    /// <summary>
+    /// Represents a directory on a physical filesystem
+    /// </summary>
     public class PhysicalDirectoryInfo : IFileInfo
     {
         private readonly DirectoryInfo _info;
-
+        
+        /// <summary>
+        /// Initializes an instance of <see cref="PhysicalDirectoryInfo"/> that wraps an instance of <see cref="System.IO.DirectoryInfo"/>
+        /// </summary>
+        /// <param name="info">The directory</param>
         public PhysicalDirectoryInfo(DirectoryInfo info)
         {
             _info = info;
         }
 
+        /// <inheritdoc />
         public bool Exists => _info.Exists;
 
+        /// <summary>
+        /// Always equals -1.
+        /// </summary>
         public long Length => -1;
 
+        /// <inheritdoc />
         public string PhysicalPath => _info.FullName;
 
+        /// <inheritdoc />
         public string Name => _info.Name;
 
+        /// <summary>
+        /// The time when the directory was last written to. 
+        /// </summary>
         public DateTimeOffset LastModified => _info.LastWriteTimeUtc;
 
+        /// <summary>
+        /// Always true.
+        /// </summary>
         public bool IsDirectory => true;
 
+        /// <summary>
+        /// Always throws an exception because read streams are not support on directories.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Always thrown</exception>
+        /// <returns></returns>
         public Stream CreateReadStream()
         {
             throw new InvalidOperationException("Cannot create a stream for a directory.");

--- a/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileInfo.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileInfo.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         /// <summary>
         /// Initializes an instance of <see cref="PhysicalFileInfo"/> that wraps an instance of <see cref="System.IO.FileInfo"/>
         /// </summary>
-        /// <param name="info"></param>
+        /// <param name="info">The <see cref="System.IO.FileInfo"/></param>
         public PhysicalFileInfo(FileInfo info)
         {
             _info = info;

--- a/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileInfo.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileInfo.cs
@@ -6,27 +6,43 @@ using System.IO;
 
 namespace Microsoft.Extensions.FileProviders.Physical
 {
+    /// <summary>
+    /// Represents a file on a physical filesystem
+    /// </summary>
     public class PhysicalFileInfo : IFileInfo
     {
         private readonly FileInfo _info;
 
+        /// <summary>
+        /// Initializes an instance of <see cref="PhysicalFileInfo"/> that wraps an instance of <see cref="System.IO.FileInfo"/>
+        /// </summary>
+        /// <param name="info"></param>
         public PhysicalFileInfo(FileInfo info)
         {
             _info = info;
         }
 
+        /// <inheritdoc />
         public bool Exists => _info.Exists;
 
+        /// <inheritdoc />
         public long Length => _info.Length;
 
+        /// <inheritdoc />
         public string PhysicalPath => _info.FullName;
 
+        /// <inheritdoc />
         public string Name => _info.Name;
 
+        /// <inheritdoc />
         public DateTimeOffset LastModified => _info.LastWriteTimeUtc;
 
+        /// <summary>
+        /// Always false.
+        /// </summary>
         public bool IsDirectory => false;
 
+        /// <inheritdoc />
         public Stream CreateReadStream()
         {
             // We are setting buffer size to 1 to prevent FileStream from allocating it's internal buffer

--- a/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileProvider.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFileProvider.cs
@@ -5,26 +5,35 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.FileProviders.Physical;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.FileProviders
 {
     /// <summary>
     /// Looks up files using the on-disk file system
     /// </summary>
+    /// <remarks>
+    /// When the environment variable "DOTNET_USE_POLLING_FILE_WATCHER" is set to "1" or "true", calls to
+    /// <see cref="Watch(string)" /> will use <see cref="PollingFileChangeToken" />.
+    /// </remarks>
     public class PhysicalFileProvider : IFileProvider, IDisposable
     {
         private const string PollingEnvironmentKey = "DOTNET_USE_POLLING_FILE_WATCHER";
+
         private static readonly char[] _invalidFileNameChars = Path.GetInvalidFileNameChars()
             .Where(c => c != Path.DirectorySeparatorChar && c != Path.AltDirectorySeparatorChar).ToArray();
+
         private static readonly char[] _invalidFilterChars = _invalidFileNameChars
             .Where(c => c != '*' && c != '|' && c != '?').ToArray();
-        private static readonly char[] _pathSeparators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+        private static readonly char[] _pathSeparators = new[]
+            {Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar};
+
         private readonly PhysicalFilesWatcher _filesWatcher;
 
         /// <summary>
-        /// Creates a new instance of a PhysicalFileProvider at the given root directory.
+        /// Initializes a new instance of a PhysicalFileProvider at the given root directory.
         /// </summary>
         /// <param name="root">The root directory. This should be an absolute path.</param>
         public PhysicalFileProvider(string root)
@@ -53,12 +62,15 @@ namespace Microsoft.Extensions.FileProviders
         {
             var environmentValue = Environment.GetEnvironmentVariable(PollingEnvironmentKey);
             var pollForChanges = string.Equals(environmentValue, "1", StringComparison.Ordinal) ||
-                string.Equals(environmentValue, "true", StringComparison.OrdinalIgnoreCase);
+                                 string.Equals(environmentValue, "true", StringComparison.OrdinalIgnoreCase);
 
             root = EnsureTrailingSlash(Path.GetFullPath(root));
             return new PhysicalFilesWatcher(root, new FileSystemWatcher(root), pollForChanges);
         }
 
+        /// <summary>
+        /// Disposes the provider. Change tokens may not trigger after the provider is disposed.
+        /// </summary>
         public void Dispose()
         {
             _filesWatcher.Dispose();
@@ -188,8 +200,12 @@ namespace Microsoft.Extensions.FileProviders
         /// <summary>
         /// Enumerate a directory at the given path, if any.
         /// </summary>
-        /// <param name="subpath">A path under the root directory</param>
-        /// <returns>Contents of the directory. Caller must check Exists property.</returns>
+        /// <param name="subpath">A path under the root directory. Leading slashes are ignored.</param>
+        /// <returns>
+        /// Contents of the directory. Caller must check Exists property. <see cref="NotFoundDirectoryContents" /> if
+        /// <paramref name="subpath" /> is absolute, if the directory does not exist, or <paramref name="subpath" /> has invalid
+        /// characters.
+        /// </returns>
         public IDirectoryContents GetDirectoryContents(string subpath)
         {
             try
@@ -230,7 +246,7 @@ namespace Microsoft.Extensions.FileProviders
                         }
                         else
                         {
-                            virtualInfos.Add(new PhysicalDirectoryInfo((DirectoryInfo)fileSystemInfo));
+                            virtualInfos.Add(new PhysicalDirectoryInfo((DirectoryInfo) fileSystemInfo));
                         }
                     }
 
@@ -246,6 +262,21 @@ namespace Microsoft.Extensions.FileProviders
             return new NotFoundDirectoryContents();
         }
 
+
+        /// <summary>
+        ///     <para>Creates a <see cref="IChangeToken" /> for the specified <paramref name="filter" />.</para>
+        ///     <para>Globbing patterns are interpreted by <seealso cref="Microsoft.Extensions.FileSystemGlobbing.Matcher" />.</para>
+        /// </summary>
+        /// <param name="filter">
+        /// Filter string used to determine what files or folders to monitor. Example: **/*.cs, *.*,
+        /// subFolder/**/*.cshtml.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IChangeToken" /> that is notified when a file matching <paramref name="filter" /> is added,
+        /// modified or deleted. Returns a <see cref="NullChangeToken" /> if <paramref name="filter" /> has invalid filter
+        /// characters or if <paramref name="filter" /> is an absolute path or outside the root directory specified in the
+        /// constructor <seealso cref="PhysicalFileProvider(string)" />.
+        /// </returns>
         public IChangeToken Watch(string filter)
         {
             if (filter == null || HasInvalidFilterChars(filter))

--- a/src/Microsoft.Extensions.FileProviders.Physical/PollingFileChangeToken.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PollingFileChangeToken.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         /// Initializes a new instance of <see cref="PollingFileChangeToken" /> that polls the specified file for changes as
         /// determined by <see cref="System.IO.FileSystemInfo.LastWriteTimeUtc" />.
         /// </summary>
-        /// <param name="fileInfo"></param>
+        /// <param name="fileInfo">The <see cref="System.IO.FileInfo"/> to poll</param>
         public PollingFileChangeToken(FileInfo fileInfo)
         {
             _fileInfo = fileInfo;
@@ -89,8 +89,8 @@ namespace Microsoft.Extensions.FileProviders.Physical
         /// <summary>
         /// Does not actually register callbacks.
         /// </summary>
-        /// <param name="callback"></param>
-        /// <param name="state"></param>
+        /// <param name="callback">This parameter is ignored</param>
+        /// <param name="state">This parameter is ignored</param>
         /// <returns>A disposable object that noops when disposed</returns>
         public IDisposable RegisterChangeCallback(Action<object> callback, object state) => EmptyDisposable.Instance;
     }

--- a/src/Microsoft.Extensions.FileProviders.Physical/PollingFileChangeToken.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PollingFileChangeToken.cs
@@ -7,6 +7,19 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.FileProviders.Physical
 {
+    /// <summary>
+    ///     <para>
+    ///     A change token that polls for file system changes.
+    ///     </para>
+    ///     <para>
+    ///     This change token does not raise any change callbacks. Callers should watch for <see cref="HasChanged" /> to turn
+    ///     from false to true
+    ///     and dispose the token after this happens.
+    ///     </para>
+    /// </summary>
+    /// <remarks>
+    /// Polling occurs every 4 seconds.
+    /// </remarks>
     public class PollingFileChangeToken : IChangeToken
     {
         private readonly FileInfo _fileInfo;
@@ -14,6 +27,11 @@ namespace Microsoft.Extensions.FileProviders.Physical
         private DateTime _lastCheckedTimeUtc;
         private bool _hasChanged;
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="PollingFileChangeToken" /> that polls the specified file for changes as
+        /// determined by <see cref="System.IO.FileSystemInfo.LastWriteTimeUtc" />.
+        /// </summary>
+        /// <param name="fileInfo"></param>
         public PollingFileChangeToken(FileInfo fileInfo)
         {
             _fileInfo = fileInfo;
@@ -29,16 +47,24 @@ namespace Microsoft.Extensions.FileProviders.Physical
             return _fileInfo.Exists ? _fileInfo.LastWriteTimeUtc : DateTime.MinValue;
         }
 
+        /// <summary>
+        /// Always false.
+        /// </summary>
         public bool ActiveChangeCallbacks => false;
 
+        /// <summary>
+        /// True when the file has changed since the change token was created. Once the file changes, this value is always true
+        /// </summary>
+        /// <remarks>
+        /// Once true, the value will always be true. Change tokens should not re-used once expired. The caller should discard this
+        /// instance once it sees <see cref="HasChanged" /> is true.
+        /// </remarks>
         public bool HasChanged
         {
             get
             {
                 if (_hasChanged)
                 {
-                    // Return true, if the change token ever changed in the past. The expecatation is that change tokens
-                    // are not re-used once expired, so the caller must discard this instance once it sees it has changed.
                     return _hasChanged;
                 }
 
@@ -60,6 +86,12 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
         }
 
+        /// <summary>
+        /// Does not actually register callbacks.
+        /// </summary>
+        /// <param name="callback"></param>
+        /// <param name="state"></param>
+        /// <returns>A disposable object that noops when disposed</returns>
         public IDisposable RegisterChangeCallback(Action<object> callback, object state) => EmptyDisposable.Instance;
     }
 }

--- a/src/Microsoft.Extensions.FileProviders.Physical/project.json
+++ b/src/Microsoft.Extensions.FileProviders.Physical/project.json
@@ -3,9 +3,6 @@
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",
-    "nowarn": [
-      "CS1591"
-    ],
     "xmlDoc": true
   },
   "description": "File provider for physical files for Microsoft.Extensions.FileProviders.",


### PR DESCRIPTION
Add documentation for the public API surface. Includes documentation on hidden behaviors, such as the 'DOTNET_USE_POLLING_FILE_WATCHER' environment variable

cc @troydai 