### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.Extensions.FileProviders.Composite.Tests/Microsoft.Extensions.FileProviders.Composite.Tests.csproj
+++ b/test/Microsoft.Extensions.FileProviders.Composite.Tests/Microsoft.Extensions.FileProviders.Composite.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Extensions.FileProviders.Embedded.Tests/Microsoft.Extensions.FileProviders.Embedded.Tests.csproj
+++ b/test/Microsoft.Extensions.FileProviders.Embedded.Tests/Microsoft.Extensions.FileProviders.Embedded.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Extensions.FileProviders.Physical.Tests/Microsoft.Extensions.FileProviders.Physical.Tests.csproj
+++ b/test/Microsoft.Extensions.FileProviders.Physical.Tests/Microsoft.Extensions.FileProviders.Physical.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Extensions.FileSystemGlobbing.Tests/Microsoft.Extensions.FileSystemGlobbing.Tests.csproj
+++ b/test/Microsoft.Extensions.FileSystemGlobbing.Tests/Microsoft.Extensions.FileSystemGlobbing.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows