### PR TITLE
Remove optional parameter from DirectoryInfoWrapper ctor

### DIFF
--- a/src/Microsoft.Extensions.FileSystemGlobbing/Abstractions/DirectoryInfoWrapper.cs
+++ b/src/Microsoft.Extensions.FileSystemGlobbing/Abstractions/DirectoryInfoWrapper.cs
@@ -19,13 +19,12 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Abstractions
         /// <summary>
         /// Initializes an instance of <see cref="DirectoryInfoWrapper" />.
         /// </summary>
-        /// <param name="directoryInfo">The <see cref="System.IO.DirectoryInfo" /></param>
-        /// <param name="isParentPath">
-        /// <c>true</c> when the <paramref name="directoryInfo" /> should be represented as the parent
-        /// directory with '..'
-        /// </param>
-        // TODO issue #229. Should isParentPath be exposed publically? It is an internal implementation detail
-        public DirectoryInfoWrapper(DirectoryInfo directoryInfo, bool isParentPath = false)
+        /// <param name="directoryInfo">The <see cref="DirectoryInfo" />.</param>
+        public DirectoryInfoWrapper(DirectoryInfo directoryInfo)
+            : this(directoryInfo, isParentPath: false)
+        { }
+
+        private DirectoryInfoWrapper(DirectoryInfo directoryInfo, bool isParentPath)
         {
             _directoryInfo = directoryInfo;
             _isParentPath = isParentPath;

--- a/src/Microsoft.Extensions.FileSystemGlobbing/breakingchanges.netcore.json
+++ b/src/Microsoft.Extensions.FileSystemGlobbing/breakingchanges.netcore.json
@@ -1,0 +1,7 @@
+[
+    {
+        "TypeId": "public class Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper : Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase",
+        "MemberId": "public .ctor(System.IO.DirectoryInfo directoryInfo, System.Boolean isParentPath = False)",
+        "Kind": "Removal"
+    }
+]


### PR DESCRIPTION
Resolves #229. The 'isParentPath' parameter on DirectoryInfoWrapper was only meant to be an internal implementation detail, and should not be exposed publicly.

Technically, this qualifies as a breaking change, which is why we waited until 2.0 to do this. I believe the risk is very low as this is a very obscure API, and the removed parameter was optional to begin with.

cc @muratg 