### PR TITLE
Remove empty helper type from physical file provider

### DIFF
--- a/src/Microsoft.Extensions.FileProviders.Physical/FileSystemInfoHelper.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/FileSystemInfoHelper.cs
@@ -5,13 +5,9 @@ using System.IO;
 
 namespace Microsoft.Extensions.FileProviders
 {
-    /// <summary>
-    /// Helper functions for working with the filesystem
-    /// </summary>
-    // TODO 2.0 make this internal
-    public class FileSystemInfoHelper
+    internal static class FileSystemInfoHelper
     {
-        internal static bool IsHiddenFile(FileSystemInfo fileSystemInfo)
+        public static bool IsHiddenFile(FileSystemInfo fileSystemInfo)
         {
             if (fileSystemInfo.Name.StartsWith("."))
             {

--- a/src/Microsoft.Extensions.FileProviders.Physical/breakingchanges.netcore.json
+++ b/src/Microsoft.Extensions.FileProviders.Physical/breakingchanges.netcore.json
@@ -1,0 +1,6 @@
+[
+  {
+    "TypeId": "public class Microsoft.Extensions.FileProviders.FileSystemInfoHelper",
+    "Kind": "Removal"
+  }
+]


### PR DESCRIPTION
One more minor cleanup item.

Microsoft.Extensions.FileProviders.FileSystemInfoHelper was mistakenly made 'public' in 1.0. It is an empty type with no public methods or properties, so although technically breaking, there is no reason anyone should have used this API.