### PR TITLE
Fix crash when OnFileSystemEntryChange is called with root path

### DIFF
--- a/src/FS.Physical/PhysicalFilesWatcher.cs
+++ b/src/FS.Physical/PhysicalFilesWatcher.cs
@@ -255,7 +255,11 @@ namespace Microsoft.Extensions.FileProviders.Physical
                 }
 
                 var relativePath = fullPath.Substring(_root.Length);
-                ReportChangeForMatchedEntries(relativePath);
+
+                if (relativePath != string.Empty)
+                {
+                    ReportChangeForMatchedEntries(relativePath);
+                }
             }
             catch (Exception ex) when (
                 ex is IOException ||


### PR DESCRIPTION
It is possible for `OnFileSystemEntryChange` to be called with root path. In that case, `ReportChangeForMatchedEntries` would be called with an empty string leading to a crash.

Addresses #299
  
  