### PR TITLE
use StartWith with StringComparison.Ordinal to properly detect hidden files on Linux

### DIFF
--- a/src/Microsoft.Extensions.FileProviders.Physical/FileSystemInfoHelper.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/FileSystemInfoHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 
 namespace Microsoft.Extensions.FileProviders
@@ -9,7 +10,7 @@ namespace Microsoft.Extensions.FileProviders
     {
         public static bool IsHiddenFile(FileSystemInfo fileSystemInfo)
         {
-            if (fileSystemInfo.Name.StartsWith("."))
+            if (fileSystemInfo.Name.StartsWith(".", StringComparison.Ordinal))
             {
                 return true;
             }


### PR DESCRIPTION
When detecting if the file is hidden or not we need to use StartWith together with StringComparison.Ordinal otherwise in some cultures all files will be hidden.

I see this issue is already fixed in dev branch but I suggest to fix it in the next release as well.
