### PR TITLE
Handle flaky OnRenamed events more gracefully

### DIFF
--- a/src/FS.Physical/PhysicalFilesWatcher.cs
+++ b/src/FS.Physical/PhysicalFilesWatcher.cs
@@ -268,6 +268,14 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
         private void ReportChangeForMatchedEntries(string path)
         {
+            if (string.IsNullOrEmpty(path))
+            {
+                // System.IO.FileSystemWatcher may trigger events that are missing the file name,
+                // which makes it appear as if the root directory is renamed or deleted. Moving the root directory
+                // of the file watcher is not supported, so this type of event is ignored.
+                return;
+            }
+
             path = NormalizePath(path);
 
             var matched = false;

--- a/test/FS.Physical.Tests/PhysicalFileProviderTests.cs
+++ b/test/FS.Physical.Tests/PhysicalFileProviderTests.cs
@@ -437,7 +437,7 @@ namespace Microsoft.Extensions.FileProviders
                             Assert.True(token.ActiveChangeCallbacks);
 
                             fileSystemWatcher.CallOnDeleted(new FileSystemEventArgs(WatcherChangeTypes.Deleted, root.RootPath, fileName));
-                            await Task.Delay(WaitTimeForTokenToFire);
+                            await Task.Delay(WaitTimeForTokenToFire).ConfigureAwait(false);
 
                             Assert.True(token.HasChanged);
                         }

--- a/test/FS.Physical.Tests/PhysicalFileProviderTests.cs
+++ b/test/FS.Physical.Tests/PhysicalFileProviderTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.FileProviders
 {
     public class PhysicalFileProviderTests
     {
-        private const int WaitTimeForTokenToFire = 2 * 100;
+        private const int WaitTimeForTokenToFire = 500;
 
         [Fact]
         public void GetFileInfoReturnsNotFoundFileInfoForNullPath()
@@ -338,8 +338,8 @@ namespace Microsoft.Extensions.FileProviders
                         {
                             var token = provider.Watch(fileName);
                             Assert.NotNull(token);
-                            Assert.False(token.HasChanged);
-                            Assert.True(token.ActiveChangeCallbacks);
+                            Assert.False(token.HasChanged, "Token should not have changed yet");
+                            Assert.True(token.ActiveChangeCallbacks, "Token should have active callbacks");
 
                             bool callbackInvoked = false;
                             token.RegisterChangeCallback(state =>
@@ -350,7 +350,7 @@ namespace Microsoft.Extensions.FileProviders
                             fileSystemWatcher.CallOnChanged(new FileSystemEventArgs(WatcherChangeTypes.Changed, root.RootPath, fileName));
                             await Task.Delay(WaitTimeForTokenToFire);
 
-                            Assert.True(callbackInvoked);
+                            Assert.True(callbackInvoked, "Callback should have been invoked");
                         }
                     }
                 }

--- a/test/FS.Physical.Tests/PhysicalFilesWatcherTests.cs
+++ b/test/FS.Physical.Tests/PhysicalFilesWatcherTests.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Extensions.FileProviders.Physical.Tests
 {
     public class PhysicalFilesWatcherTests
     {
+        private const int WaitTimeForTokenToFire = 500;
+
         [Fact]
         public void CreateFileChangeToken_DoesNotAllowPathsAboveRoot()
         {
@@ -23,6 +26,26 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
 
                 token = physicalFilesWatcher.CreateFileChangeToken("..");
                 Assert.IsType<NullChangeToken>(token);
+            }
+        }
+
+        [Fact]
+        public async Task HandlesOnRenamedEventsThatMatchRootPath()
+        {
+            using (var root = new DisposableFileSystem())
+            using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
+            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+            {
+                var token = physicalFilesWatcher.CreateFileChangeToken("**");
+                var called = false;
+                token.RegisterChangeCallback(o => called = true, null);
+
+                fileSystemWatcher.CallOnRenamed(new RenamedEventArgs(WatcherChangeTypes.Renamed, root.RootPath, string.Empty, string.Empty));
+                Assert.False(called, "Callback should not have been triggered");
+
+                fileSystemWatcher.CallOnRenamed(new RenamedEventArgs(WatcherChangeTypes.Renamed, root.RootPath, "old.txt", "new.txt"));
+                await Task.Delay(WaitTimeForTokenToFire);
+                Assert.True(called, "Callback should have been triggered");
             }
         }
     }

--- a/test/FS.Physical.Tests/PhysicalFilesWatcherTests.cs
+++ b/test/FS.Physical.Tests/PhysicalFilesWatcherTests.cs
@@ -41,10 +41,11 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
                 token.RegisterChangeCallback(o => called = true, null);
 
                 fileSystemWatcher.CallOnRenamed(new RenamedEventArgs(WatcherChangeTypes.Renamed, root.RootPath, string.Empty, string.Empty));
+                await Task.Delay(WaitTimeForTokenToFire).ConfigureAwait(false);
                 Assert.False(called, "Callback should not have been triggered");
 
                 fileSystemWatcher.CallOnRenamed(new RenamedEventArgs(WatcherChangeTypes.Renamed, root.RootPath, "old.txt", "new.txt"));
-                await Task.Delay(WaitTimeForTokenToFire);
+                await Task.Delay(WaitTimeForTokenToFire).ConfigureAwait(false);
                 Assert.True(called, "Callback should have been triggered");
             }
         }


### PR DESCRIPTION
In some conditions, System.IO.FileSystemWatcher will raise OnRenamed without the new file name. This causes an ArgumentException when attempting to determine if this file change should trigger a change token.

Resolves https://github.com/aspnet/Home/issues/2536

cc @dpoole73