### PR TITLE
[2.0.x] handle flaky OnRenamed events more gracefully

### DIFF
--- a/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFilesWatcher.cs
+++ b/src/Microsoft.Extensions.FileProviders.Physical/PhysicalFilesWatcher.cs
@@ -245,6 +245,14 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
         private void ReportChangeForMatchedEntries(string path)
         {
+            if (string.IsNullOrEmpty(path))
+            {
+                // System.IO.FileSystemWatcher may trigger events that are missing the file name,
+                // which makes it appear as if the root directory is renamed or deleted. Moving the root directory
+                // of the file watcher is not supported, so this type of event is ignored.
+                return;
+            }
+
             path = NormalizePath(path);
 
             var matched = false;

--- a/test/Microsoft.Extensions.FileProviders.Physical.Tests/PhysicalFileProviderTests.cs
+++ b/test/Microsoft.Extensions.FileProviders.Physical.Tests/PhysicalFileProviderTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.FileProviders
 {
     public class PhysicalFileProviderTests
     {
-        private const int WaitTimeForTokenToFire = 2 * 100;
+        private const int WaitTimeForTokenToFire = 500;
 
         [Fact]
         public void GetFileInfoReturnsNotFoundFileInfoForNullPath()
@@ -320,8 +320,8 @@ namespace Microsoft.Extensions.FileProviders
                         {
                             var token = provider.Watch(fileName);
                             Assert.NotNull(token);
-                            Assert.False(token.HasChanged);
-                            Assert.True(token.ActiveChangeCallbacks);
+                            Assert.False(token.HasChanged, "Token should not have changed yet");
+                            Assert.True(token.ActiveChangeCallbacks, "Token should have active callbacks");
 
                             bool callbackInvoked = false;
                             token.RegisterChangeCallback(state =>
@@ -332,7 +332,7 @@ namespace Microsoft.Extensions.FileProviders
                             fileSystemWatcher.CallOnChanged(new FileSystemEventArgs(WatcherChangeTypes.Changed, root.RootPath, fileName));
                             await Task.Delay(WaitTimeForTokenToFire);
 
-                            Assert.True(callbackInvoked);
+                            Assert.True(callbackInvoked, "Callback should have been invoked");
                         }
                     }
                 }
@@ -419,7 +419,7 @@ namespace Microsoft.Extensions.FileProviders
                             Assert.True(token.ActiveChangeCallbacks);
 
                             fileSystemWatcher.CallOnDeleted(new FileSystemEventArgs(WatcherChangeTypes.Deleted, root.RootPath, fileName));
-                            await Task.Delay(WaitTimeForTokenToFire);
+                            await Task.Delay(WaitTimeForTokenToFire).ConfigureAwait(false);
 
                             Assert.True(token.HasChanged);
                         }

--- a/test/Microsoft.Extensions.FileProviders.Physical.Tests/PhysicalFilesWatcherTests.cs
+++ b/test/Microsoft.Extensions.FileProviders.Physical.Tests/PhysicalFilesWatcherTests.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Extensions.FileProviders.Physical.Tests
 {
     public class PhysicalFilesWatcherTests
     {
+        private const int WaitTimeForTokenToFire = 500;
+
         [Fact]
         public void CreateFileChangeToken_DoesNotAllowPathsAboveRoot()
         {
@@ -23,6 +26,27 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
 
                 token = physicalFilesWatcher.CreateFileChangeToken("..");
                 Assert.IsType<NullChangeToken>(token);
+            }
+        }
+
+        [Fact]
+        public async Task HandlesOnRenamedEventsThatMatchRootPath()
+        {
+            using (var root = new DisposableFileSystem())
+            using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
+            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+            {
+                var token = physicalFilesWatcher.CreateFileChangeToken("**");
+                var called = false;
+                token.RegisterChangeCallback(o => called = true, null);
+
+                fileSystemWatcher.CallOnRenamed(new RenamedEventArgs(WatcherChangeTypes.Renamed, root.RootPath, string.Empty, string.Empty));
+                await Task.Delay(WaitTimeForTokenToFire).ConfigureAwait(false);
+                Assert.False(called, "Callback should not have been triggered");
+
+                fileSystemWatcher.CallOnRenamed(new RenamedEventArgs(WatcherChangeTypes.Renamed, root.RootPath, "old.txt", "new.txt"));
+                await Task.Delay(WaitTimeForTokenToFire).ConfigureAwait(false);
+                Assert.True(called, "Callback should have been triggered");
             }
         }
     }


### PR DESCRIPTION
Backports #314 to the 2.0.x release branch, with the addition of a quirks mode switch in the event this causes unforseen behavior issues.

Resolves aspnet/Home#2808

cc @Eilon 