### PR TITLE
Don't capture AsyncLocals to PhysicalFilesWatcher

### DIFF
--- a/test/FS.Physical.Tests/PhysicalFileProviderTests.cs
+++ b/test/FS.Physical.Tests/PhysicalFileProviderTests.cs
@@ -937,51 +937,6 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         [Fact]
-        public async Task AsyncLocalsNotCapturedToEvents()
-        {
-            // Capture clean context
-            var executionContext = ExecutionContext.Capture();
-
-            var asyncLocal = new AsyncLocal<int>();
-            asyncLocal.Value = 1;
-
-            using (var root = new DisposableFileSystem())
-            {
-                using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
-                {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
-                    {
-                        Assert.Equal(1, asyncLocal.Value);
-                        using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
-                        {
-                            var name = Guid.NewGuid().ToString();
-                            var token = provider.Watch(name);
-                            var didFire = false;
-                            
-                            token.RegisterChangeCallback(al =>
-                            {
-                                Assert.Equal(0, ((AsyncLocal<int>)al).Value);
-                                didFire = true;
-                            }, asyncLocal);
-
-                            // Fire in clean context
-                            ExecutionContext.Run(
-                                executionContext,
-                                _ => fileSystemWatcher.CallOnChanged(new FileSystemEventArgs(WatcherChangeTypes.Created, root.RootPath, name))
-                                , null);
-
-                            await Task.Delay(WaitTimeForTokenToFire);
-
-                            Assert.True(didFire);
-                            Assert.True(token.HasChanged);
-                            Assert.Equal(1, asyncLocal.Value);
-                        }
-                    }
-                }
-            }
-        }
-
-        [Fact]
         public async Task TokenFiredOnDeletion()
         {
             using (var root = new DisposableFileSystem())


### PR DESCRIPTION
This causes a problem with `IHttpContextAccessor` as it captures the `HttpContext` and everything linked to it causing a lot of memory to become rooted (as seen in https://github.com/aspnet/KestrelHttpServer/issues/2840#issuecomment-416034872)

![image](https://user-images.githubusercontent.com/1142958/44632256-51954080-a96f-11e8-8971-b1be25aaef9a.png)


/cc @davidfowl 