### PR TITLE
Simplify file watching

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -10,6 +10,7 @@
     <MicrosoftBuildTasksCorePackageVersion>15.6.82</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.6.82</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-alpha1-10454</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
+    <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>3.0.0-alpha1-10454</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
     <MicrosoftExtensionsPrimitivesPackageVersion>3.0.0-alpha1-10454</MicrosoftExtensionsPrimitivesPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.3</MicrosoftNETCoreApp21PackageVersion>

--- a/src/FS.Physical/FS.Physical.csproj
+++ b/src/FS.Physical/FS.Physical.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\FS.Globbing\FS.Globbing.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.NonCapturingTimer.Sources" Version="$(MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/src/FS.Physical/IFileWatcher.cs
+++ b/src/FS.Physical/IFileWatcher.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading;
+using System;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.FileProviders
 {
-    internal interface IPollingChangeToken : IChangeToken
+    internal interface IFileWatcher : IDisposable
     {
-        CancellationTokenSource CancellationTokenSource { get; }
-
-        bool UpdateHasChanged();
+        IChangeToken CreateFileChangeToken(string filter);
     }
 }

--- a/src/FS.Physical/PollingFileChangeToken.cs
+++ b/src/FS.Physical/PollingFileChangeToken.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Microsoft.Extensions.Primitives;
@@ -25,10 +24,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
     public class PollingFileChangeToken : IPollingChangeToken
     {
         private readonly FileInfo _fileInfo;
-        private DateTime _previousWriteTimeUtc;
-        private DateTime _lastCheckedTimeUtc;
-        private bool _hasChanged;
-        private CancellationTokenSource _tokenSource;
+        private DateTime _initialWriteTimeUtc;
         private CancellationChangeToken _changeToken;
 
         /// <summary>
@@ -36,14 +32,15 @@ namespace Microsoft.Extensions.FileProviders.Physical
         /// determined by <see cref="System.IO.FileSystemInfo.LastWriteTimeUtc" />.
         /// </summary>
         /// <param name="fileInfo">The <see cref="System.IO.FileInfo"/> to poll</param>
-        public PollingFileChangeToken(FileInfo fileInfo)
+        /// <param name="cancellationTokenSource">The <see cref="System.Threading.CancellationTokenSource"/>.</param>
+        public PollingFileChangeToken(FileInfo fileInfo, CancellationTokenSource cancellationTokenSource)
         {
             _fileInfo = fileInfo;
-            _previousWriteTimeUtc = GetLastWriteTimeUtc();
-        }
+            CancellationTokenSource = cancellationTokenSource;
+            _changeToken = new CancellationChangeToken(cancellationTokenSource.Token);
 
-        // Internal for unit testing
-        internal static TimeSpan PollingInterval { get; set; } = PhysicalFilesWatcher.DefaultPollingInterval;
+            _initialWriteTimeUtc = GetLastWriteTimeUtc();
+        }
 
         private DateTime GetLastWriteTimeUtc()
         {
@@ -51,24 +48,13 @@ namespace Microsoft.Extensions.FileProviders.Physical
             return _fileInfo.Exists ? _fileInfo.LastWriteTimeUtc : DateTime.MinValue;
         }
 
+        /// <inheritdoc />
+        public bool ActiveChangeCallbacks => true;
+
         /// <summary>
-        /// Always false.
+        /// Gets the <see cref="System.Threading.CancellationTokenSource"/>.
         /// </summary>
-        public bool ActiveChangeCallbacks { get; internal set; }
-
-        internal CancellationTokenSource CancellationTokenSource
-        {
-            get => _tokenSource;
-            set
-            {
-                Debug.Assert(_tokenSource == null, "We expect CancellationTokenSource to be initialized exactly once.");
-
-                _tokenSource = value;
-                _changeToken = new CancellationChangeToken(_tokenSource.Token);
-            }
-        }
-
-        CancellationTokenSource IPollingChangeToken.CancellationTokenSource => CancellationTokenSource;
+        public CancellationTokenSource CancellationTokenSource { get; }
 
         /// <summary>
         /// True when the file has changed since the change token was created. Once the file changes, this value is always true
@@ -77,46 +63,27 @@ namespace Microsoft.Extensions.FileProviders.Physical
         /// Once true, the value will always be true. Change tokens should not re-used once expired. The caller should discard this
         /// instance once it sees <see cref="HasChanged" /> is true.
         /// </remarks>
-        public bool HasChanged
-        {
-            get
-            {
-                if (_hasChanged)
-                {
-                    return _hasChanged;
-                }
-
-                var currentTime = DateTime.UtcNow;
-                if (currentTime - _lastCheckedTimeUtc < PollingInterval)
-                {
-                    return _hasChanged;
-                }
-
-                var lastWriteTimeUtc = GetLastWriteTimeUtc();
-                if (_previousWriteTimeUtc != lastWriteTimeUtc)
-                {
-                    _previousWriteTimeUtc = lastWriteTimeUtc;
-                    _hasChanged = true;
-                }
-
-                _lastCheckedTimeUtc = currentTime;
-                return _hasChanged;
-            }
-        }
+        public bool HasChanged { get; private set; }
 
         /// <summary>
-        /// Does not actually register callbacks.
+        /// Updates <see cref="HasChanged"/>.
         /// </summary>
-        /// <param name="callback">This parameter is ignored</param>
-        /// <param name="state">This parameter is ignored</param>
-        /// <returns>A disposable object that noops when disposed</returns>
+        /// <returns>The updated value of <see cref="HasChanged"/>.</returns>
+        public bool UpdateHasChanged()
+        {
+            HasChanged |= CalculateChange();
+            return HasChanged;
+        }
+
+        private bool CalculateChange()
+        {
+            var lastWriteTimeUtc = GetLastWriteTimeUtc();
+            return _initialWriteTimeUtc != lastWriteTimeUtc;
+        }
+
+        /// <inheritdoc />
         public IDisposable RegisterChangeCallback(Action<object> callback, object state)
         {
-            if (!ActiveChangeCallbacks)
-            {
-                return EmptyDisposable.Instance;
-            }
-
             return _changeToken.RegisterChangeCallback(callback, state);
         }
     }

--- a/src/FS.Physical/PollingFileWatcher.cs
+++ b/src/FS.Physical/PollingFileWatcher.cs
@@ -1,0 +1,120 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading;
+using Microsoft.Extensions.FileProviders.Physical.Internal;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Extensions.FileProviders.Physical
+{
+    internal sealed class PollingFileWatcher : IFileWatcher
+    {
+        public static readonly TimeSpan DefaultPollingInterval = TimeSpan.FromSeconds(4);
+        private readonly string _root;
+        private readonly Timer _timer;
+
+        public PollingFileWatcher(string root, TimeSpan pollingInterval)
+        {
+            _root = root;
+            PollingChangeTokens = new ConcurrentDictionary<string, IPollingChangeToken>(StringComparer.Ordinal);
+
+            // PhysicalFileProvider lazy initializes IFileWatcher instances. It's OK for us to initialize this in the ctor since we anticipate
+            // GetFileChangeToken to be invoked right after.
+            _timer = new Timer(RaiseChangeEvents, state: PollingChangeTokens, dueTime: pollingInterval, period: pollingInterval);
+        }
+
+        public ConcurrentDictionary<string, IPollingChangeToken> PollingChangeTokens { get; }
+
+        public IChangeToken CreateFileChangeToken(string filter)
+        {
+            if (filter == null)
+            {
+                throw new ArgumentNullException(nameof(filter));
+            }
+
+            filter = NormalizePath(filter);
+
+            // Absolute paths and paths traversing above root not permitted.
+            if (Path.IsPathRooted(filter) || PathUtils.PathNavigatesAboveRoot(filter))
+            {
+                return NullChangeToken.Singleton;
+            }
+
+            var changeToken = GetOrAddChangeToken(filter);
+            return changeToken;
+        }
+
+        public IChangeToken GetOrAddChangeToken(string pattern)
+        {
+            if (PollingChangeTokens.TryGetValue(pattern, out var changeToken) && !changeToken.HasChanged)
+            {
+                return changeToken;
+            }
+
+            var isWildCard = pattern.IndexOf('*') != -1;
+            var tokenSource = new CancellationTokenSource();
+            if (isWildCard || IsDirectoryPath(pattern))
+            {
+                changeToken = new PollingWildCardChangeToken(_root, pattern, tokenSource);
+            }
+            else
+            {
+                var fileInfo = new FileInfo(Path.Combine(_root, pattern));
+                changeToken = new PollingFileChangeToken(fileInfo, tokenSource);
+            }
+
+            return PollingChangeTokens.GetOrAdd(pattern, changeToken);
+        }
+
+        public void Dispose()
+        {
+            _timer.Dispose();
+        }
+
+        ~PollingFileWatcher() => Dispose();
+
+        private static string NormalizePath(string filter) => filter = filter.Replace('\\', '/');
+
+        private static bool IsDirectoryPath(string path)
+        {
+            return path.Length > 0 &&
+                (path[path.Length - 1] == Path.DirectorySeparatorChar ||
+                path[path.Length - 1] == Path.AltDirectorySeparatorChar);
+        }
+
+        internal static void RaiseChangeEvents(object state)
+        {
+            // Iterating over a concurrent bag gives us a point in time snapshot making it safe
+            // to remove items from it.
+            var changeTokens = (ConcurrentDictionary<string, IPollingChangeToken>)state;
+            foreach (var item in changeTokens)
+            {
+                var token = item.Value;
+
+                if (!token.UpdateHasChanged())
+                {
+                    continue;
+                }
+
+                if (!changeTokens.TryRemove(item.Key, out _))
+                {
+                    // Move on if we couldn't remove the item.
+                    continue;
+                }
+
+                // We're already on a background thread, don't need to spawn a background Task to cancel the CTS
+                try
+                {
+                    token.CancellationTokenSource.Cancel();
+                }
+                catch
+                {
+
+                }
+            }
+        }
+    }
+}

--- a/src/FS.Physical/PollingFileWatcher.cs
+++ b/src/FS.Physical/PollingFileWatcher.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Threading;
 using Microsoft.Extensions.FileProviders.Physical.Internal;
+using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.FileProviders.Physical
@@ -23,7 +24,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
             // PhysicalFileProvider lazy initializes IFileWatcher instances. It's OK for us to initialize this in the ctor since we anticipate
             // GetFileChangeToken to be invoked right after.
-            _timer = new Timer(RaiseChangeEvents, state: PollingChangeTokens, dueTime: pollingInterval, period: pollingInterval);
+            _timer = NonCapturingTimer.Create(RaiseChangeEvents, state: PollingChangeTokens, dueTime: pollingInterval, period: pollingInterval);
         }
 
         public ConcurrentDictionary<string, IPollingChangeToken> PollingChangeTokens { get; }

--- a/src/FS.Physical/breakingchanges.netcore.json
+++ b/src/FS.Physical/breakingchanges.netcore.json
@@ -1,0 +1,22 @@
+﻿[
+  {
+    "TypeId": "public class Microsoft.Extensions.FileProviders.Physical.PollingFileChangeToken : Microsoft.Extensions.Primitives.IChangeToken",
+    "MemberId": "public .ctor(System.IO.FileInfo fileInfo)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher : System.IDisposable",
+    "MemberId": "public .ctor(System.String root, System.IO.FileSystemWatcher fileSystemWatcher, System.Boolean pollForChanges)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher : System.IDisposable",
+    "MemberId": "public .ctor(System.String root, System.IO.FileSystemWatcher fileSystemWatcher, System.Boolean pollForChanges, Microsoft.Extensions.FileProviders.Physical.ExclusionFilters filters)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.Extensions.FileProviders.Physical.PollingWildCardChangeToken : Microsoft.Extensions.Primitives.IChangeToken",
+    "MemberId": "public .ctor(System.String root, System.String pattern)",
+    "Kind": "Removal"
+  }
+]

--- a/test/FS.Physical.Tests/PhysicalFileProviderTests.cs
+++ b/test/FS.Physical.Tests/PhysicalFileProviderTests.cs
@@ -4,13 +4,11 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.FileProviders.Internal;
 using Microsoft.Extensions.FileProviders.Physical;
-using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace Microsoft.Extensions.FileProviders
@@ -303,7 +301,7 @@ namespace Microsoft.Extensions.FileProviders
 
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -332,7 +330,7 @@ namespace Microsoft.Extensions.FileProviders
 
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -358,66 +356,6 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         [Fact]
-        public async Task WatcherWithPolling_ReturnsTrueForFileChangedWhenFileSystemWatcherDoesNotRaiseEvents()
-        {
-            using (var root = new DisposableFileSystem())
-            {
-                var fileName = Path.GetRandomFileName();
-                var fileLocation = Path.Combine(root.RootPath, fileName);
-                PollingFileChangeToken.PollingInterval = TimeSpan.FromMilliseconds(10);
-
-                // emptyRoot is not used for creating and modifying files,
-                // but is passed into the MockFileSystemWatcher so FileSystemWatcher events aren't triggered
-                // during file changes in the test
-                using (var emptyRoot = new DisposableFileSystem())
-                using (var fileSystemWatcher = new MockFileSystemWatcher(emptyRoot.RootPath))
-                {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: true))
-                    {
-                        using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
-                        {
-                            var token = provider.Watch(fileName);
-                            File.WriteAllText(fileLocation, "some-content");
-                            await Task.Delay(WaitTimeForTokenToFire);
-                            Assert.True(token.HasChanged);
-                        }
-                    }
-                }
-            }
-        }
-
-        [Fact]
-        public async Task WatcherWithPolling_ReturnsTrueForFileRemovedWhenFileSystemWatcherDoesNotRaiseEvents()
-        {
-            using (var root = new DisposableFileSystem())
-            {
-                var fileName = Path.GetRandomFileName();
-                var fileLocation = Path.Combine(root.RootPath, fileName);
-                PollingFileChangeToken.PollingInterval = TimeSpan.FromMilliseconds(10);
-
-                // emptyRoot is not used for creating and modifying files,
-                // but is passed into the MockFileSystemWatcher so FileSystemWatcher events aren't triggered
-                // during file changes in the test
-                using (var emptyRoot = new DisposableFileSystem())
-                using (var fileSystemWatcher = new MockFileSystemWatcher(emptyRoot.RootPath))
-                {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: true))
-                    {
-                        using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
-                        {
-                            root.CreateFile(fileName);
-                            var token = provider.Watch(fileName);
-                            File.Delete(fileLocation);
-
-                            await Task.Delay(WaitTimeForTokenToFire);
-                            Assert.True(token.HasChanged);
-                        }
-                    }
-                }
-            }
-        }
-
-        [Fact]
         public async Task TokensFiredOnFileDeleted()
         {
             using (var root = new DisposableFileSystem())
@@ -427,7 +365,7 @@ namespace Microsoft.Extensions.FileProviders
 
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -734,7 +672,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -780,7 +718,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -812,7 +750,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -918,7 +856,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -942,7 +880,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -966,7 +904,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -1023,7 +961,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -1064,7 +1002,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -1089,7 +1027,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -1136,7 +1074,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -1168,7 +1106,7 @@ namespace Microsoft.Extensions.FileProviders
 
             using (var root = new DisposableFileSystem())
             using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
-            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
             using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
             {
                 var oldDirectoryName = Guid.NewGuid().ToString();
@@ -1236,7 +1174,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -1274,7 +1212,7 @@ namespace Microsoft.Extensions.FileProviders
 
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -1301,7 +1239,7 @@ namespace Microsoft.Extensions.FileProviders
             {
                 using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
                 {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.Sensitive))
                     {
                         using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
                         {
@@ -1322,78 +1260,34 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         [Fact]
-        public async Task WildCardToken_RaisesEventsForNewFilesAdded()
+        public void CreateFileWatcher_CreatesPhysicalFileWatcher_WhenNotPolling()
         {
             // Arrange
             using (var root = new DisposableFileSystem())
-            using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
-            using (var physicalFilesWatcher = new PhysicalFilesWatcher(
-                root.RootPath + Path.DirectorySeparatorChar,
-                fileSystemWatcher,
-                pollForChanges: false))
-
-            using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
+            using (var provider = new PhysicalFileProvider(root.RootPath))
             {
-                var token = provider.Watch("**/*.txt");
-                var directory = Path.Combine(root.RootPath, "subdir1", "subdir2");
-
                 // Act
-                fileSystemWatcher.CallOnCreated(new FileSystemEventArgs(WatcherChangeTypes.Created, directory, "a.txt"));
-                await Task.Delay(WaitTimeForTokenToFire);
+                var fileWatcher = provider.CreateFileWatcher();
 
                 // Assert
-                Assert.True(token.HasChanged);
+                Assert.IsType<PhysicalFilesWatcher>(fileWatcher);
             }
         }
 
         [Fact]
-        public async Task WildCardToken_RaisesEventsWhenFileSystemWatcherDoesNotFire()
-        {
-            // Arrange
-            using (var root = new DisposableFileSystem())
-            using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
-            using (var physicalFilesWatcher = new PhysicalFilesWatcher(
-                root.RootPath + Path.DirectorySeparatorChar,
-                fileSystemWatcher,
-                pollForChanges: true))
-
-            using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
-            {
-                var filePath = Path.Combine(root.RootPath, "subdir1", "subdir2", "file.txt");
-                Directory.CreateDirectory(Path.GetDirectoryName(filePath));
-                File.WriteAllText(filePath, "some-content");
-                var token = provider.Watch("**/*.txt");
-                var compositeToken = Assert.IsType<CompositeChangeToken>(token);
-                Assert.Equal(2, compositeToken.ChangeTokens.Count);
-                var pollingChangeToken = Assert.IsType<PollingWildCardChangeToken>(compositeToken.ChangeTokens[1]);
-                pollingChangeToken.PollingInterval = TimeSpan.FromMilliseconds(10);
-
-                // Act
-                fileSystemWatcher.EnableRaisingEvents = false;
-                File.Delete(filePath);
-                await Task.Delay(WaitTimeForTokenToFire);
-
-                // Assert
-                Assert.True(token.HasChanged);
-            }
-        }
-
-        [Fact]
-        public void CreateFileWatcher_CreatesWatcherWithPollingAndActiveFlags()
+        public void CreateFileWatcher_CreatesPollingFileWatcher_WhenPolling()
         {
             // Arrange
             using (var root = new DisposableFileSystem())
             using (var provider = new PhysicalFileProvider(root.RootPath))
             {
                 provider.UsePollingFileWatcher = true;
-                provider.UseActivePolling = true;
 
                 // Act
                 var fileWatcher = provider.CreateFileWatcher();
 
                 // Assert
-                Assert.True(fileWatcher.PollForChanges);
-                Assert.True(fileWatcher.UseActivePolling);
+                Assert.IsType<PollingFileWatcher>(fileWatcher);
             }
         }
     }

--- a/test/FS.Physical.Tests/PhysicalFilesWatcherTests.cs
+++ b/test/FS.Physical.Tests/PhysicalFilesWatcherTests.cs
@@ -1,14 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Concurrent;
 using System.IO;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Primitives;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Extensions.FileProviders.Physical.Tests
@@ -22,7 +16,7 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
         {
             using (var root = new DisposableFileSystem())
             using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
-            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.None))
             {
                 var token = physicalFilesWatcher.CreateFileChangeToken(Path.GetFullPath(Path.Combine(root.RootPath, "..")));
                 Assert.IsType<NullChangeToken>(token);
@@ -40,7 +34,7 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
         {
             using (var root = new DisposableFileSystem())
             using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
-            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, ExclusionFilters.None))
             {
                 var token = physicalFilesWatcher.CreateFileChangeToken("**");
                 var called = false;
@@ -53,183 +47,6 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
                 fileSystemWatcher.CallOnRenamed(new RenamedEventArgs(WatcherChangeTypes.Renamed, root.RootPath, "old.txt", "new.txt"));
                 await Task.Delay(WaitTimeForTokenToFire).ConfigureAwait(false);
                 Assert.True(called, "Callback should have been triggered");
-            }
-        }
-
-        [Fact]
-        public void RaiseChangeEvents_CancelsCancellationTokenSourceForExpiredTokens()
-        {
-            // Arrange
-            var cts1 = new CancellationTokenSource();
-            var cts2 = new CancellationTokenSource();
-            var cts3 = new CancellationTokenSource();
-
-            var token1 = new TestPollingChangeToken { Id = 1, CancellationTokenSource = cts1 };
-            var token2 = new TestPollingChangeToken { Id = 2, HasChanged = true, CancellationTokenSource = cts2 };
-            var token3 = new TestPollingChangeToken { Id = 3, CancellationTokenSource = cts3 };
-
-            var tokens = new ConcurrentDictionary<IPollingChangeToken, IPollingChangeToken>
-            {
-                [token1] = token1,
-                [token2] = token2,
-                [token3] = token3,
-            };
-
-            // Act
-            PhysicalFilesWatcher.RaiseChangeEvents(tokens);
-
-            // Assert
-            Assert.False(cts1.IsCancellationRequested);
-            Assert.False(cts3.IsCancellationRequested);
-            Assert.True(cts2.IsCancellationRequested);
-
-            // Ensure token2 is removed from the collection.
-            Assert.Equal(new[] { token1, token3, }, tokens.Keys.OfType<TestPollingChangeToken>().OrderBy(t => t.Id));
-        }
-
-        [Fact]
-        public void RaiseChangeEvents_CancelsAndRemovesMultipleChangedTokens()
-        {
-            // Arrange
-            var cts1 = new CancellationTokenSource();
-            var cts2 = new CancellationTokenSource();
-            var cts3 = new CancellationTokenSource();
-            var cts4 = new CancellationTokenSource();
-            var cts5 = new CancellationTokenSource();
-
-            var token1 = new TestPollingChangeToken { Id = 1, HasChanged = true, CancellationTokenSource = cts1 };
-            var token2 = new TestPollingChangeToken { Id = 2, CancellationTokenSource = cts2 };
-            var token3 = new TestPollingChangeToken { Id = 3, CancellationTokenSource = cts3 };
-            var token4 = new TestPollingChangeToken { Id = 4, HasChanged = true, CancellationTokenSource = cts4 };
-            var token5 = new TestPollingChangeToken { Id = 5, HasChanged = true, CancellationTokenSource = cts5 };
-
-            var tokens = new ConcurrentDictionary<IPollingChangeToken, IPollingChangeToken>
-            {
-                [token1] = token1,
-                [token2] = token2,
-                [token3] = token3,
-                [token4] = token4,
-                [token5] = token5,
-            };
-
-            // Act
-            PhysicalFilesWatcher.RaiseChangeEvents(tokens);
-
-            // Assert
-            Assert.False(cts2.IsCancellationRequested);
-            Assert.False(cts3.IsCancellationRequested);
-
-            Assert.True(cts1.IsCancellationRequested);
-            Assert.True(cts4.IsCancellationRequested);
-            Assert.True(cts5.IsCancellationRequested);
-
-            // Ensure changed tokens are removed
-            Assert.Equal(new[] { token2, token3, }, tokens.Keys.OfType<TestPollingChangeToken>().OrderBy(t => t.Id));
-        }
-
-        [Fact]
-        public void GetOrAddFilePathChangeToken_AddsPollingChangeTokenWithCancellationToken_WhenActiveCallbackIsTrue()
-        {
-            using (var root = new DisposableFileSystem())
-            using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
-            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: true))
-            {
-                physicalFilesWatcher.UseActivePolling = true;
-
-                var changeToken = physicalFilesWatcher.GetOrAddFilePathChangeToken("some-path");
-
-                var compositeChangeToken = Assert.IsType<CompositeChangeToken>(changeToken);
-                Assert.Collection(
-                    compositeChangeToken.ChangeTokens,
-                    token => Assert.IsType<CancellationChangeToken>(token),
-                    token =>
-                    {
-                        var pollingChangeToken = Assert.IsType<PollingFileChangeToken>(token);
-                        Assert.NotNull(pollingChangeToken.CancellationTokenSource);
-                        Assert.True(pollingChangeToken.ActiveChangeCallbacks);
-                    });
-
-                Assert.NotEmpty(physicalFilesWatcher.PollingChangeTokens);
-            }
-        }
-
-        [Fact]
-        public void GetOrAddFilePathChangeToken_AddsPollingChangeTokenWhenPollingIsEnabled()
-        {
-            using (var root = new DisposableFileSystem())
-            using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
-            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: true))
-            {
-                var changeToken = physicalFilesWatcher.GetOrAddFilePathChangeToken("some-path");
-
-                var compositeChangeToken = Assert.IsType<CompositeChangeToken>(changeToken);
-                Assert.Collection(
-                    compositeChangeToken.ChangeTokens,
-                    token => Assert.IsType<CancellationChangeToken>(token),
-                    token =>
-                    {
-                        var pollingChangeToken = Assert.IsType<PollingFileChangeToken>(token);
-                        Assert.Null(pollingChangeToken.CancellationTokenSource);
-                        Assert.False(pollingChangeToken.ActiveChangeCallbacks);
-                    });
-
-                Assert.Empty(physicalFilesWatcher.PollingChangeTokens);
-            }
-        }
-
-        [Fact]
-        public void GetOrAddFilePathChangeToken_DoesNotAddsPollingChangeTokenWhenCallbackIsDisabled()
-        {
-            using (var root = new DisposableFileSystem())
-            using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
-            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
-            {
-                var changeToken = physicalFilesWatcher.GetOrAddFilePathChangeToken("some-path");
-
-                Assert.IsType<CancellationChangeToken>(changeToken);
-                Assert.Empty(physicalFilesWatcher.PollingChangeTokens);
-            }
-        }
-
-        [Fact]
-        public void GetOrAddWildcardChangeToken_AddsPollingChangeTokenWithCancellationToken_WhenActiveCallbackIsTrue()
-        {
-            using (var root = new DisposableFileSystem())
-            using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
-            using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: true))
-            {
-                physicalFilesWatcher.UseActivePolling = true;
-
-                var changeToken = physicalFilesWatcher.GetOrAddWildcardChangeToken("*.cshtml");
-
-                var compositeChangeToken = Assert.IsType<CompositeChangeToken>(changeToken);
-                Assert.Collection(
-                    compositeChangeToken.ChangeTokens,
-                    token => Assert.IsType<CancellationChangeToken>(token),
-                    token =>
-                    {
-                        var pollingChangeToken = Assert.IsType<PollingWildCardChangeToken>(token);
-                        Assert.NotNull(pollingChangeToken.CancellationTokenSource);
-                        Assert.True(pollingChangeToken.ActiveChangeCallbacks);
-                    });
-
-                Assert.NotEmpty(physicalFilesWatcher.PollingChangeTokens);
-            }
-        }
-
-        private class TestPollingChangeToken : IPollingChangeToken
-        {
-            public int Id { get; set; }
-
-            public CancellationTokenSource CancellationTokenSource { get; set; }
-
-            public bool HasChanged { get; set; }
-
-            public bool ActiveChangeCallbacks => throw new NotImplementedException();
-
-            public IDisposable RegisterChangeCallback(Action<object> callback, object state)
-            {
-                throw new NotImplementedException();
             }
         }
     }

--- a/test/FS.Physical.Tests/PollingFileWatcherTest.cs
+++ b/test/FS.Physical.Tests/PollingFileWatcherTest.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace Microsoft.Extensions.FileProviders.Physical
+{
+    public class PollingFileWatcherTest
+    {
+        private static readonly TimeSpan NeverStartTimer = TimeSpan.FromMilliseconds(-1);
+
+        [Fact]
+        public void GetOrAddFileChangeToken_WithFilePath_CreatesPollingFileChangeToken()
+        {
+            using (var fileSystem = new DisposableFileSystem())
+            using (var fileWatcher = new PollingFileWatcher(fileSystem.RootPath, NeverStartTimer))
+            {
+                var changeToken = fileWatcher.GetOrAddChangeToken("test.txt");
+                Assert.IsType<PollingFileChangeToken>(changeToken);
+                Assert.False(changeToken.HasChanged);
+            }
+        }
+
+        [Fact]
+        public void GetOrAddFileChangeToken_WithGlobbingPattern_CreatesPollingWildCardChangeToken()
+        {
+            using (var fileSystem = new DisposableFileSystem())
+            using (var fileWatcher = new PollingFileWatcher(fileSystem.RootPath, NeverStartTimer))
+            {
+                var changeToken = fileWatcher.GetOrAddChangeToken("*/*.txt");
+                Assert.IsType<PollingWildCardChangeToken>(changeToken);
+                Assert.False(changeToken.HasChanged);
+            }
+        }
+
+        [Fact]
+        public void RaiseChangeEvents_CancelsCancellationTokenSourceForExpiredTokens()
+        {
+            // Arrange
+            var cts1 = new CancellationTokenSource();
+            var cts2 = new CancellationTokenSource();
+            var cts3 = new CancellationTokenSource();
+
+            var token1 = new TestPollingChangeToken { Id = "1", CancellationTokenSource = cts1 };
+            var token2 = new TestPollingChangeToken { Id = "2", HasChanged = true, CancellationTokenSource = cts2 };
+            var token3 = new TestPollingChangeToken { Id = "3", CancellationTokenSource = cts3 };
+
+            var tokens = CreateDictionary(token1, token2, token3);
+
+            // Act
+            PollingFileWatcher.RaiseChangeEvents(tokens);
+
+            // Assert
+            Assert.False(cts1.IsCancellationRequested);
+            Assert.False(cts3.IsCancellationRequested);
+            Assert.True(cts2.IsCancellationRequested);
+
+            // Ensure token2 is removed from the collection.
+            Assert.Equal(new[] { token1, token3, }, tokens.OrderBy(t => t.Key).Select(t => t.Value));
+        }
+
+        [Fact]
+        public void RaiseChangeEvents_CancelsAndRemovesMultipleChangedTokens()
+        {
+            // Arrange
+            var cts1 = new CancellationTokenSource();
+            var cts2 = new CancellationTokenSource();
+            var cts3 = new CancellationTokenSource();
+            var cts4 = new CancellationTokenSource();
+            var cts5 = new CancellationTokenSource();
+
+            var token1 = new TestPollingChangeToken { Id = "1", HasChanged = true, CancellationTokenSource = cts1 };
+            var token2 = new TestPollingChangeToken { Id = "2", CancellationTokenSource = cts2 };
+            var token3 = new TestPollingChangeToken { Id = "3", CancellationTokenSource = cts3 };
+            var token4 = new TestPollingChangeToken { Id = "4", HasChanged = true, CancellationTokenSource = cts4 };
+            var token5 = new TestPollingChangeToken { Id = "5", HasChanged = true, CancellationTokenSource = cts5 };
+
+            var tokens = CreateDictionary(token1, token2, token3, token4, token5);
+
+            // Act
+            PollingFileWatcher.RaiseChangeEvents(tokens);
+
+            // Assert
+            Assert.False(cts2.IsCancellationRequested);
+            Assert.False(cts3.IsCancellationRequested);
+
+            Assert.True(cts1.IsCancellationRequested);
+            Assert.True(cts4.IsCancellationRequested);
+            Assert.True(cts5.IsCancellationRequested);
+
+            // Ensure changed tokens are removed
+            Assert.Equal(new[] { token2, token3, }, tokens.OrderBy(t => t.Key).Select(t => t.Value));
+        }
+
+        private static ConcurrentDictionary<string, IPollingChangeToken> CreateDictionary(params TestPollingChangeToken[] tokens)
+        {
+            return new ConcurrentDictionary<string, IPollingChangeToken>(tokens.ToDictionary(t => t.Id, t => (IPollingChangeToken)t));
+        }
+
+        private class TestPollingChangeToken : IPollingChangeToken
+        {
+            public string Id { get; set; }
+
+            public CancellationTokenSource CancellationTokenSource { get; set; }
+
+            public bool HasChanged { get; set; }
+
+            public bool ActiveChangeCallbacks => throw new NotImplementedException();
+
+            public IDisposable RegisterChangeCallback(Action<object> callback, object state)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool UpdateHasChanged() => HasChanged;
+        }
+    }
+}

--- a/test/FS.Physical.Tests/TestClock.cs
+++ b/test/FS.Physical.Tests/TestClock.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.FileProviders.Physical.Internal
 
         public void Increment()
         {
-            UtcNow = UtcNow.Add(PhysicalFilesWatcher.DefaultPollingInterval);
+            UtcNow = UtcNow.Add(PollingFileWatcher.DefaultPollingInterval);
         }
     }
 }


### PR DESCRIPTION
* Disable FileSystemWatcher when polling is enabled.
* Let the PollingFileWatcher determine when polling change tokens need to refresh