### PR TITLE
Update tasks for netstandard2.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,10 +5,10 @@
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181004.7</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10584</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftBuildFrameworkPackageVersion>15.6.82</MicrosoftBuildFrameworkPackageVersion>
-    <MicrosoftBuildPackageVersion>15.6.82</MicrosoftBuildPackageVersion>
-    <MicrosoftBuildTasksCorePackageVersion>15.6.82</MicrosoftBuildTasksCorePackageVersion>
-    <MicrosoftBuildUtilitiesCorePackageVersion>15.6.82</MicrosoftBuildUtilitiesCorePackageVersion>
+    <MicrosoftBuildFrameworkPackageVersion>15.8.166</MicrosoftBuildFrameworkPackageVersion>
+    <MicrosoftBuildPackageVersion>15.8.166</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildTasksCorePackageVersion>15.8.166</MicrosoftBuildTasksCorePackageVersion>
+    <MicrosoftBuildUtilitiesCorePackageVersion>15.8.166</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-alpha1-10584</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>3.0.0-alpha1-10584</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
     <MicrosoftExtensionsPrimitivesPackageVersion>3.0.0-alpha1-10584</MicrosoftExtensionsPrimitivesPackageVersion>

--- a/src/FS.Embedded.Manifest.Task/FS.Embedded.Manifest.Task.csproj
+++ b/src/FS.Embedded.Manifest.Task/FS.Embedded.Manifest.Task.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Microsoft.Extensions.FileProviders.Embedded.Manifest.Task</AssemblyName>
     <Description>MSBuild task to generate a manifest that can be used by Microsoft.Extensions.FileProviders.Embedded to preserve
     metadata of the files embedded in the assembly at compilation time.</Description>
-    <TargetFrameworks>netstandard1.5;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <EnableApiCheck>false</EnableApiCheck>
     <IsPackable>false</IsPackable>

--- a/src/FS.Embedded/FS.Embedded.csproj
+++ b/src/FS.Embedded/FS.Embedded.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <SignedPackageFile Include="$(TargetPath)" PackagePath="lib/$(TargetFramework)/$(TargetFileName)" Certificate="$(AssemblySigningCertName)" />
-    <SignedPackageFile Include="$(MSBuildThisFileDirectory)..\FS.Embedded.Manifest.Task\bin\$(Configuration)\netstandard1.5\$(AssemblyName).Manifest.Task.dll" PackagePath="tasks/netstandard1.5/Microsoft.Extensions.FileProviders.Embedded.Manifest.Task.dll" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="$(MSBuildThisFileDirectory)..\FS.Embedded.Manifest.Task\bin\$(Configuration)\netstandard2.0\$(AssemblyName).Manifest.Task.dll" PackagePath="tasks/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.Manifest.Task.dll" Certificate="$(AssemblySigningCertName)" />
     <SignedPackageFile Include="$(MSBuildThisFileDirectory)..\FS.Embedded.Manifest.Task\bin\$(Configuration)\net461\$(AssemblyName).Manifest.Task.dll" PackagePath="tasks/net461/Microsoft.Extensions.FileProviders.Embedded.Manifest.Task.dll" Certificate="$(AssemblySigningCertName)" />
   </ItemGroup>
 
@@ -49,8 +49,8 @@
         OutputDocumentation=@(DocumentationProjectOutputGroupOutput);
 
         <!-- Include the assembly and symbols from the tasks project -->
-        TaskAssemblyNetStandard=..\FS.Embedded.Manifest.Task\bin\$(Configuration)\netstandard1.5\$(AssemblyName).Manifest.Task.dll;
-        TaskSymbolNetStandard=..\FS.Embedded.Manifest.Task\bin\$(Configuration)\netstandard1.5\$(AssemblyName).Manifest.Task.pdb;
+        TaskAssemblyNetStandard=..\FS.Embedded.Manifest.Task\bin\$(Configuration)\netstandard2.0\$(AssemblyName).Manifest.Task.dll;
+        TaskSymbolNetStandard=..\FS.Embedded.Manifest.Task\bin\$(Configuration)\netstandard2.0\$(AssemblyName).Manifest.Task.pdb;
         TaskAssemblyNet461=..\FS.Embedded.Manifest.Task\bin\$(Configuration)\net461\$(AssemblyName).Manifest.Task.dll;
         TaskSymbolNet461=..\FS.Embedded.Manifest.Task\bin\$(Configuration)\net461\$(AssemblyName).Manifest.Task.pdb;
       </NuspecProperties>

--- a/src/FS.Embedded/FS.Embedded.nuspec
+++ b/src/FS.Embedded/FS.Embedded.nuspec
@@ -25,8 +25,8 @@
     <file src="$OutputDocumentation$" target="lib\$targetframework$\" />
     <file src="build\**\*" target="build\" />
     <file src="buildMultiTargeting\**\*" target="buildMultiTargeting\" />
-    <file src="$TaskAssemblyNetStandard$" target="tasks\netstandard1.5\$AssemblyName$.Manifest.Task.dll" />
-    <file src="$TaskSymbolNetStandard$" target="tasks\netstandard1.5\$AssemblyName$.Manifest.Task.pdb" />
+    <file src="$TaskAssemblyNetStandard$" target="tasks\netstandard2.0\$AssemblyName$.Manifest.Task.dll" />
+    <file src="$TaskSymbolNetStandard$" target="tasks\netstandard2.0\$AssemblyName$.Manifest.Task.pdb" />
     <file src="$TaskAssemblyNet461$" target="tasks\net461\$AssemblyName$.Manifest.Task.dll" />
     <file src="$TaskSymbolNet461$" target="tasks\net461\$AssemblyName$.Manifest.Task.pdb" />
   </files>

--- a/src/FS.Embedded/build/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.props
+++ b/src/FS.Embedded/build/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <_FileProviderTaskFolder Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard1.5</_FileProviderTaskFolder>
+    <_FileProviderTaskFolder Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard2.0</_FileProviderTaskFolder>
     <_FileProviderTaskFolder Condition="'$(MSBuildRuntimeType)' != 'Core'">net461</_FileProviderTaskFolder>
     <_FileProviderTaskAssembly>$(MSBuildThisFileDirectory)..\..\tasks\$(_FileProviderTaskFolder)\Microsoft.Extensions.FileProviders.Embedded.Manifest.Task.dll</_FileProviderTaskAssembly>
   </PropertyGroup>


### PR DESCRIPTION
The 15.8 version of MSBuild dropped support for netstandard1.5

This is resolves a build break in UniverseCoherence